### PR TITLE
feat/JwtSetting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,24 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
+
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modureview/config/SecurityConfig.java
+++ b/src/main/java/com/modureview/config/SecurityConfig.java
@@ -1,0 +1,68 @@
+package com.modureview.config;
+
+import com.modureview.fIlter.JwtAuthenticationFilter;
+import com.modureview.handler.OAuth2LoginFailureHandler;
+import com.modureview.handler.OAuth2LoginSuccessHandler;
+import com.modureview.service.CustomOAuth2UserService;
+import com.modureview.service.utill.CustomAuthenticationEntryPoint;
+import com.modureview.service.utill.JwtTokenizer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final JwtTokenizer jwtTokenizer;
+  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+  private final CustomOAuth2UserService customOAuth2UserService;
+  private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+  private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+
+  String [] allAllowPage = new String[]{};
+  String[] userAllowPage = new String[]{};
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+    http
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/api/v0/user/checkEmail", "/user/oauth2/**", "/api/v0/token/refresh","/api/v0/user/logout").permitAll()
+            .anyRequest().authenticated()
+        )
+        .cors(Customizer.withDefaults())
+        .csrf(csrf -> csrf.disable())
+        .httpBasic(auth -> auth.disable())
+        .formLogin(auth -> auth.disable())
+        .logout(auth -> auth.disable())
+        .sessionManagement(auth -> auth.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .addFilterBefore(new JwtAuthenticationFilter(jwtTokenizer,customAuthenticationEntryPoint),
+            UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(exception -> exception.authenticationEntryPoint(customAuthenticationEntryPoint))
+        .oauth2Login(oauth2 -> oauth2
+            .authorizationEndpoint(endpoint -> endpoint.baseUri("/oauth2/authorize"))
+            .redirectionEndpoint(endpoint -> endpoint.baseUri("/login/oauth2/code/**"))
+            .userInfoEndpoint(endpoint -> endpoint.userService(customOAuth2UserService))
+            .successHandler(oAuth2LoginSuccessHandler)
+            .failureHandler(oAuth2LoginFailureHandler)
+        );
+    return http.build();
+  }
+
+  @Bean
+  public BCryptPasswordEncoder bCryptPasswordEncoder(){
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/com/modureview/config/WebConfig.java
+++ b/src/main/java/com/modureview/config/WebConfig.java
@@ -1,0 +1,32 @@
+package com.modureview.config;
+
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Value("${app.cors.allowed-origins}")
+  private String allowedOrigins;
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource(){
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(List.of(allowedOrigins));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(List.of("*"));
+    configuration.setExposedHeaders(List.of("Authorization"));
+    configuration.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
+}

--- a/src/main/java/com/modureview/controller/RefreshTokenController.java
+++ b/src/main/java/com/modureview/controller/RefreshTokenController.java
@@ -1,0 +1,37 @@
+package com.modureview.controller;
+
+
+import com.modureview.entity.User;
+import com.modureview.repository.UserRepository;
+import com.modureview.service.utill.JwtTokenizer;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v0/token")
+public class RefreshTokenController {
+  private final JwtTokenizer jwtTokenizer;
+  private final UserRepository userRepository;
+
+  @GetMapping("/refresh")
+  public ResponseEntity<?> refreshToken(@CookieValue(name = "refreshToken") String refreshToken, HttpServletResponse response){
+    if(jwtTokenizer.validateToken(refreshToken)){
+      Claims claims = jwtTokenizer.parseRefreshToken(refreshToken);
+      User user = userRepository.findByEmail(claims.getSubject()).orElseThrow(
+          ()->new RuntimeException("User not found with email: "+claims.getSubject())
+      );
+      jwtTokenizer.reissueTokenPair(response,user);
+      return ResponseEntity.status(HttpStatus.CREATED).body("access token refreshed successfully");
+    }else{
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+  }
+}

--- a/src/main/java/com/modureview/entity/RefreshToken.java
+++ b/src/main/java/com/modureview/entity/RefreshToken.java
@@ -1,0 +1,40 @@
+package com.modureview.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long Id;
+
+  @ManyToOne
+  @JoinColumn(name = "user_Id",nullable = false)
+  private User user;
+
+  @Column(name = "value",length = 500)
+  private String value;
+
+  public void setMappingUser(User user){
+    this.user = user;
+    user.getRefreshTokens().add(this);
+  }
+
+
+}

--- a/src/main/java/com/modureview/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/modureview/exception/JwtAuthenticationException.java
@@ -1,0 +1,12 @@
+package com.modureview.exception;
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+  public JwtAuthenticationException(String msg, Throwable t) {
+    super(msg, t);
+  }
+
+  public JwtAuthenticationException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/modureview/fIlter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/modureview/fIlter/JwtAuthenticationFilter.java
@@ -1,0 +1,90 @@
+package com.modureview.fIlter;
+
+import com.modureview.exception.JwtAuthenticationException;
+import com.modureview.service.utill.CustomAuthenticationEntryPoint;
+
+import com.modureview.service.utill.CustomUserDetails;
+import com.modureview.service.utill.JwtAuthenticationToken;
+import com.modureview.service.utill.JwtTokenizer;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+  private final JwtTokenizer jwtTokenizer;
+  private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String path = request.getRequestURI();
+    return path.startsWith("/user/oauth2") || path.startsWith("/api/v0/token/refresh") || path.startsWith("/api/v0/user/logout");
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    String token = getJwtFromRequest(request);
+    log.info("===============doFilterInternal=============");
+    log.info("UserRequest url ::{}", request.getRequestURI());
+
+    try {
+      if (StringUtils.hasText(token)) {
+        Claims claims = jwtTokenizer.parseAccessToken(token);
+        setAuthenticationToContext(claims);
+        log.info("claims :: {}", claims);
+      } else {
+        throw new JwtAuthenticationException("Access token is missing");
+      }
+    } catch (AuthenticationException ex) {
+      SecurityContextHolder.clearContext();
+      authenticationEntryPoint.commence(request, response, ex);
+      return;
+    }
+
+    filterChain.doFilter(request, response);
+    log.info("===============doFilterInternal=============");
+  }
+
+
+  private void setAuthenticationToContext(Claims claims) {
+
+    String userEmail = claims.getSubject();
+
+
+    List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(userEmail));
+
+    CustomUserDetails userDetails = new CustomUserDetails(userEmail);
+    Authentication authentication = new JwtAuthenticationToken(authorities, userDetails, null);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  private String getJwtFromRequest(HttpServletRequest request) {
+    if (request.getCookies() != null) {
+      for (Cookie cookie : request.getCookies()) {
+        if ("accessToken".equals(cookie.getName())) {
+          log.info("Cookie :: {}", cookie.getValue());
+          return cookie.getValue();
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/modureview/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/modureview/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.modureview.repository;
+
+import com.modureview.entity.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+  Optional<RefreshToken> findByUserId(Long Id);
+
+}

--- a/src/main/java/com/modureview/service/RefreshTokenService.java
+++ b/src/main/java/com/modureview/service/RefreshTokenService.java
@@ -1,0 +1,33 @@
+package com.modureview.service;
+
+import com.modureview.entity.RefreshToken;
+
+import com.modureview.entity.User;
+import com.modureview.repository.RefreshTokenRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  public Optional<RefreshToken> getRefreshTokenByUserId(Long Id){
+    return refreshTokenRepository.findById(Id);
+  }
+
+  public void saveRefreshToken(RefreshToken refreshToken){
+     refreshTokenRepository.save(refreshToken);
+  }
+
+  public void removeRefreshTokenByUserId(Long Id){
+    getRefreshTokenByUserId(Id).ifPresent(refreshTokenRepository::delete);
+  }
+
+  public void removeRefreshTokenDB(User user){
+    refreshTokenRepository.findByUserId(user.getId()).ifPresent(refreshTokenRepository::delete);
+  }
+
+
+}

--- a/src/main/java/com/modureview/service/utill/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/modureview/service/utill/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package com.modureview.service.utill;
+
+import com.nimbusds.jose.shaded.gson.Gson;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+    log.error("Unauthorized error: {}", authException.getMessage());
+
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setCharacterEncoding("UTF-8");
+
+
+    Map<String, Object> errorResponse = new HashMap<>();
+    errorResponse.put("error", "Unauthorized");
+    errorResponse.put("message", authException.getMessage());
+    errorResponse.put("path", request.getRequestURI());
+    errorResponse.put("timestamp", LocalDateTime.now().toString());
+
+    String json = new Gson().toJson(errorResponse);
+    response.getWriter().write(json);
+  }
+}

--- a/src/main/java/com/modureview/service/utill/CustomUserDetails.java
+++ b/src/main/java/com/modureview/service/utill/CustomUserDetails.java
@@ -1,0 +1,65 @@
+package com.modureview.service.utill;
+
+
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+  private final String username;
+  private final String password;
+  private final String userEmail;
+  private final Collection<? extends GrantedAuthority> authorities;
+
+
+  public CustomUserDetails(String username, String password, String userEmail, Collection<? extends GrantedAuthority> authorities) {
+    this.username = username;
+    this.password = password;
+    this.userEmail = userEmail;
+    this.authorities = authorities;
+  }
+
+
+  public CustomUserDetails(String userEmail) {
+    this(userEmail, "", userEmail, Collections.emptyList());
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return authorities;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/com/modureview/service/utill/JwtAuthenticationToken.java
+++ b/src/main/java/com/modureview/service/utill/JwtAuthenticationToken.java
@@ -1,0 +1,22 @@
+package com.modureview.service.utill;
+
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+  private String token;
+  private Object principal;
+  private Object credentials;
+
+  public JwtAuthenticationToken(Collection<? extends GrantedAuthority> authorities,Object principal,Object credentials){
+    super(authorities);
+    this.principal = principal;
+    this.credentials = credentials;
+    this.setAuthenticated(true);
+  }
+  @Override
+  public Object getCredentials(){return null;}
+}

--- a/src/main/java/com/modureview/service/utill/JwtTokenizer.java
+++ b/src/main/java/com/modureview/service/utill/JwtTokenizer.java
@@ -1,0 +1,163 @@
+package com.modureview.service.utill;
+
+import com.modureview.entity.RefreshToken;
+import com.modureview.entity.User;
+import com.modureview.service.RefreshTokenService;
+import com.modureview.service.UserService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenizer {
+  private final RefreshTokenService refreshTokenService;
+  private final UserService userService;
+  private final byte[] accessSecretKey;
+  private final byte[] refreshSecretKey;
+
+  public static Long ACCESS_TOKEN_EXPIRATION_TIME = (Long)(2*30*10*1000L);
+  public static Long REFRESH_TOKEN_EXPIRATION_TIME = (Long)(2*60*60*1000L);
+
+
+  public JwtTokenizer(@Value("${jwt.secretKey}")String accessSecretKey,@Value("${jwt.refreshKey}")String refreshSecretKey,RefreshTokenService refreshTokenService,UserService userService){
+    this.refreshTokenService = refreshTokenService;
+    this.accessSecretKey = accessSecretKey.getBytes(StandardCharsets.UTF_8);
+    this.refreshSecretKey = refreshSecretKey.getBytes(StandardCharsets.UTF_8);
+    this.userService = userService;
+  }
+
+  
+
+  public String createToken(String email,Long expire,byte[] secretKey){
+    Claims claims = Jwts.claims().setSubject(email);
+    return Jwts.builder()
+        .setClaims(claims)
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(new Date().getTime()+expire))
+        .signWith(getSigningKey(secretKey))
+        .compact();
+  }
+
+  public String createAccessToken(User user){
+    return createToken(user.getEmail(),ACCESS_TOKEN_EXPIRATION_TIME,accessSecretKey);
+  }
+
+  public String createRefreshToken(User user){
+    return createToken(user.getEmail(),REFRESH_TOKEN_EXPIRATION_TIME,refreshSecretKey);
+  }
+
+  public Claims parseToken(String token,byte[] secretKey){
+    return Jwts.parserBuilder()
+        .setSigningKey(getSigningKey(secretKey))
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+  }
+
+  public Claims parseAccessToken(String accessToken){
+    return parseToken(accessToken,accessSecretKey);
+  }
+
+  public Claims parseRefreshToken(String refreshToken){
+    return parseToken(refreshToken,refreshSecretKey);
+  }
+
+
+  private static Key getSigningKey(byte[] secretKey) {
+    return Keys.hmacShaKeyFor(secretKey);
+  }
+
+  public void reissueTokenPair(HttpServletResponse response , User user){
+    String accessToken = createAccessToken(user);
+    String refreshToken = createRefreshToken(user);
+
+    RefreshToken refreshTokenObj = refreshTokenService.getRefreshTokenByUserId(user.getId())
+        .orElseGet(() -> {
+          RefreshToken newRefreshToken = new RefreshToken();
+          newRefreshToken.setUser(user);
+          return newRefreshToken;
+        });
+    refreshTokenObj.setValue(refreshToken);
+    refreshTokenService.saveRefreshToken(refreshTokenObj);
+    addAccessToken(response,accessToken,ACCESS_TOKEN_EXPIRATION_TIME);
+    addRefreshToken(response,refreshToken,REFRESH_TOKEN_EXPIRATION_TIME);
+    addUserCookie(response,user,ACCESS_TOKEN_EXPIRATION_TIME);
+
+    
+  }
+  
+  private void addRefreshToken(HttpServletResponse response,String tokenValue, Long expirationTime){
+    Cookie refreshToken = new Cookie("refreshToken", tokenValue);
+    refreshToken.setHttpOnly(true);
+    refreshToken.setPath("/");
+    refreshToken.setMaxAge(Math.toIntExact(expirationTime));
+    refreshToken.setSecure(true);
+    refreshToken.setAttribute("SameSite","Lax");
+    log.info("Setting Cookie - Name : {} , Value : {}",refreshToken.getName(),refreshToken);
+    response.addCookie(refreshToken);
+  }
+
+  private void addAccessToken(HttpServletResponse response,String tokenValue, Long expirationTime){
+    Cookie accessToken = new Cookie("accessToken", tokenValue);
+    accessToken.setHttpOnly(true);
+    accessToken.setPath("/");
+    accessToken.setMaxAge(Math.toIntExact(expirationTime));
+    accessToken.setSecure(true);
+    accessToken.setAttribute("SameSite","Lax");
+    log.info("Setting Cookie - Name : {} , Value : {}",accessToken.getName(),accessToken);
+    response.addCookie(accessToken);
+  }
+
+  private void addUserCookie(HttpServletResponse response,User user,Long expirationTime){
+    Cookie userCookie = new Cookie("UserEmail",user.getEmail());
+    userCookie.setHttpOnly(false);
+    userCookie.setPath("/");
+    userCookie.setMaxAge(Math.toIntExact(expirationTime));
+    userCookie.setSecure(false);
+    userCookie.setAttribute("SameSite","Lax");
+    log.info(" ========================= addUserCookie =======================");
+    log.info("Setting Cookie - Name : {}m Value : {} ",userCookie.getName(),userCookie.getValue());
+    log.info(" ========================= addUserCookie =======================");
+    response.addCookie(userCookie);
+  }
+  public boolean validateToken(String refreshToken){
+    try{
+      Jwts.parserBuilder().setSigningKey(getSigningKey(refreshSecretKey)).build().parseClaimsJws(refreshToken);
+      return true;
+    }catch (Exception e){
+      return false;
+    }
+  }
+
+  public void removeToken(HttpServletResponse response, HttpServletRequest request){
+    Cookie[] cookies = request.getCookies();
+    if(cookies != null){
+      for (Cookie cookie : cookies) {
+        if("refreshToken".equals(cookie.getName()) || "accessToken".equals(cookie.getName()) || "userCookie".equals(cookie.getName())){
+          cookie.setValue("");
+          cookie.setPath("/");
+          cookie.setMaxAge(0);
+          response.addCookie(cookie);
+        }
+      }
+    }
+  }
+  public void removeTokenFromDB(Cookie accessToken){
+    Claims claims = parseAccessToken(accessToken.getValue());
+    String userEmail = claims.getSubject();
+    refreshTokenService.removeRefreshTokenDB(userService.getUserByEmail(userEmail));
+  }
+
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=modu-review

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,92 @@
+server:
+  port: 8080
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/mydb
+    username: root
+    password: yesh@25164
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20
+      transaction-isolation: 8
+
+  thymeleaf:
+    prefix : classpath:/templates/
+    suffix : .html
+    enabled : true
+
+
+  security:
+    oauth2:
+      client:
+        registration:
+
+
+          kakao:
+            client-id: "8d8b112f9b151d0a13c2c66ea8e64aa0"
+            client-secret: "vnkc65v4zjcdQOvbXenlc7DrfHPwDfcL"
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            scope: account_email
+            authorization-grant-type: authorization_code
+            client-name: Kakao
+            client-authentication-method: client_secret_post
+
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+
+
+
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    properties:
+      hibernate:
+        hibernate:
+        "[format_sql]": true            #SQL ?? ?? ??
+        "[user_sql_comments]": true     #SQL ??? ?? ??
+        "[highlight_sql]": true         #SQL ??
+        "[hbm2ddl.auto]": update
+    open-in-view: true
+    show-sql: true
+
+
+
+  #default 1MB
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+jwt:
+
+  secretKey: 5e874ea1e818508bf966564ed5003cead95bf3f283d9c4a875c883420a62ae79
+  refreshKey: eyJhbGciOiJIUzUxMiJ9eyJzdWIiOiJ1c2VyIn0I2qOfhAZMGSH1pCecUH5sV2Lg2pSWNQMPzXsMcne6NJ1SlkBoirhGAmKfTYNcRyhu6nQtRzgAd6VXyttoX9A
+
+
+project:
+  folderPath: "files/"
+
+app:
+  cors:
+    allowed-origins: "http://localhost:3000"
+
+
+logging:
+  level:
+    org:
+      springframework:
+        web: DEBUG
+        web.filter.CommonsRequestLoggingFilter: DEBUG
+      hibernate:
+        type.descriptor.sql: TRACE
+    org.springframework.data.jpa.repository: DEBUG
+    com:
+      example: INFO
+    root: INFO


### PR DESCRIPTION
제목

JWT 기반 인증 및 리프레시 토큰 재발급 시스템 구현

변경 사항
	•	JWT 발급, 파싱, 검증, 재발급을 담당하는 JwtTokenizer 유틸 클래스 구현
	•	리프레시 토큰 관련 CRUD 비즈니스 로직을 처리하는 RefreshTokenService 및 RefreshTokenRepository 구현
	•	사용자-리프레시 토큰 관계를 구성하는 RefreshToken 엔티티 추가 및 User 엔티티와 양방향 연관 매핑 설정
	•	JWT 인증 필터(JwtAuthenticationFilter)를 통해 쿠키 기반 액세스 토큰 검증 및 인증 처리 구현
	•	인증 실패 시 JSON 형식의 오류 응답을 반환하는 CustomAuthenticationEntryPoint 구현
	•	JWT 인증에 사용되는 JwtAuthenticationToken, CustomUserDetails 구현
	•	리프레시 토큰 기반 토큰 재발급 API를 처리하는 RefreshTokenController 구현
	•	보안 필터 체인을 구성하는 SecurityConfig 및 CORS 설정을 위한 WebConfig 클래스 구현
	•	application.yml 및 Gradle 설정에서 JWT, OAuth2, DB, Security 관련 프로퍼티 추가

설명
	•	쿠키에 저장된 accessToken, refreshToken, userEmail을 기반으로 JWT 인증 처리
	•	/api/v0/token/refresh에서 리프레시 토큰 유효성 검증 후 새로운 토큰 쌍을 재발급
	•	로그아웃 시 쿠키 삭제와 함께 DB 내 리프레시 토큰도 제거
	•	JwtAuthenticationFilter는 인증이 필요 없는 경로(/user/oauth2, /token/refresh 등)를 필터링 예외 처리
	•	JwtTokenizer는 액세스/리프레시 토큰을 생성 후 쿠키로 전달하며, 재발급 및 삭제 기능 포함
	•	보안 설정(SecurityConfig)은 JWT 필터와 OAuth2 성공/실패 핸들러를 포함한 필터 체인을 구성

성능
	•	JWT 기반 무상태 인증 구조로 서버 세션 부담 최소화 및 스케일링 용이
	•	리프레시 토큰을 DB에서 직접 검증하여 보안성과 신뢰도 향상
	•	쿠키를 통한 토큰 전달 방식으로 프론트엔드-백엔드 통신 효율화
	•	JWT 클레임 파싱 후 인증 정보 설정 과정을 간결화하여 인증 속도 향상
	•	설정 클래스 분리를 통해 환경 구성의 명확성 및 관리 효율성 증대