### PR TITLE
feat(jwt인증): JWT 토큰 서비스로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modureview/service/JwtTokenService.java
+++ b/src/main/java/com/modureview/service/JwtTokenService.java
@@ -1,0 +1,60 @@
+package com.modureview.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtTokenService {
+
+  private final String secretKey = "r8FkOq5W9XzRb7K1uDwYlH3gTjLmP2Na";
+  private final Long accessTokenExpire = 60 * 60L;
+  private final Long refreshTokenExpire = 30 * 24 * 60 * 60L;
+
+  List<ResponseCookie> loginTokenIssue(String userEmail) {
+    return List.of(
+        createAccessToken(userEmail),
+        createRefreshToken(userEmail),
+        createUserEmailCookie(userEmail)
+    );
+  }
+
+  public ResponseCookie createAccessToken(String userEmail) {
+    String accessToken = createJwtToken(userEmail, accessTokenExpire, secretKey);
+    return createCookie("accessToken", accessToken, accessTokenExpire, true);
+  }
+
+  public ResponseCookie createRefreshToken(String userEmail) {
+    String refreshToken = createJwtToken(userEmail, refreshTokenExpire, secretKey);
+    return createCookie("refreshToken", refreshToken, refreshTokenExpire, true);
+  }
+
+  public ResponseCookie createUserEmailCookie(String userEmail) {
+    return createCookie("userEmail", userEmail, refreshTokenExpire, true);
+  }
+
+
+  private String createJwtToken(String subject, Long expireSeconds, String key) {
+    return Jwts.builder()
+        .setSubject(subject)
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + expireSeconds * 1000))
+        .signWith(Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8)))
+        .compact();
+  }
+
+  private ResponseCookie createCookie(String name, String value, long maxAge, boolean httpOnly) {
+    return ResponseCookie.from(name, value)
+        .httpOnly(httpOnly)
+        .secure(true)
+        .sameSite("None")
+        .path("/")
+        .maxAge(maxAge)
+        .domain(".modu-review.com")
+        .build();
+  }
+}

--- a/src/test/java/com/modureview/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/modureview/service/JwtTokenServiceTest.java
@@ -1,0 +1,56 @@
+package com.modureview.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+class JwtTokenServiceTest {
+
+  private final JwtTokenService jwtTokenService = new JwtTokenService();
+
+  @Test
+  @DisplayName("accressTokenCookie 정보 확인 테스트")
+  void isValidAccessToken() {
+    ResponseCookie accessCookie = jwtTokenService.createAccessToken("test@example.com");
+
+    assertThat(accessCookie.getName()).isEqualTo("accessToken");
+    assertThat(accessCookie.isHttpOnly()).isTrue();
+    assertThat(accessCookie.isSecure()).isTrue();
+    assertThat(accessCookie.getMaxAge().getSeconds()).isEqualTo(60 * 60L);
+    assertThat(accessCookie.getDomain()).isEqualTo(".modu-review.com");
+  }
+
+  @Test
+  @DisplayName("refreshTokenCookie 정보 확인 리스트")
+  void isValidRefreshToken() {
+    ResponseCookie refreshCookie = jwtTokenService.createRefreshToken("test@example.com");
+
+    assertThat(refreshCookie.getName()).isEqualTo("refreshToken");
+    assertThat(refreshCookie.isHttpOnly()).isTrue();
+    assertThat(refreshCookie.isSecure()).isTrue();
+    assertThat(refreshCookie.getMaxAge().getSeconds()).isEqualTo(30 * 24 * 60 * 60L);
+  }
+
+  @Test
+  @DisplayName("userEmailCookie 이름, 이메일 확인 테스트 ")
+  void userEmailCookie_shouldContainPlainEmail() {
+    ResponseCookie emailCookie = jwtTokenService.createUserEmailCookie("test@example.com");
+
+    assertThat(emailCookie.getName()).isEqualTo("userEmail");
+    assertThat(emailCookie.getValue()).isEqualTo("test@example.com");
+    assertThat(emailCookie.isHttpOnly()).isTrue();
+  }
+
+  @Test
+  @DisplayName("지정한 토큰이 잘 지정되는지 확인 ")
+  void loginTokenIssueCheck() {
+    List<ResponseCookie> cookies = jwtTokenService.loginTokenIssue("user@domain.com");
+
+    assertThat(cookies).hasSize(3);
+    assertThat(cookies.stream().map(ResponseCookie::getName).toList())
+        .containsExactlyInAnyOrder("accessToken", "refreshToken", "userEmail");
+  }
+}


### PR DESCRIPTION
## 주요 기능
JWT토큰 생성 및 UserEmailCookie생성

## 변경 사항
카카오 OAuth2인증 성공 후 필요한 JWT인증 발급 로직 구현

## 설명
JwtTokenService.java=====
AccessToken, refreshToken, userEmail쿠키 구현 생성 로직 추가

JwtTokenServiceTest.java=====
Access Token, RefreshToken, UserEmail이 정상적으로 만들어졌는지 확인


## 테스트 방법
테스트 코드 작성

<img width="693" alt="image" src="https://github.com/user-attachments/assets/16fb6536-5681-49b9-bc08-7d685dc5f079" />

테스트 코드 작성 후 정상 작동 확인
