### PR TITLE
Feat/jwt auth - jwt토큰 검증 로직 추가

### DIFF
--- a/src/main/java/com/modureview/Interceptor/JwtTokenInterceptor.java
+++ b/src/main/java/com/modureview/Interceptor/JwtTokenInterceptor.java
@@ -1,0 +1,42 @@
+package com.modureview.interceptor;
+
+import com.modureview.enums.JwtErrorCode;
+import com.modureview.exception.jwtError.InvalidTokenException;
+import com.modureview.service.JwtTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtTokenInterceptor implements HandlerInterceptor {
+
+  private final JwtTokenService jwtTokenService;
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+      Object handler) {
+    log.info("request url: {}", request.getRequestURL());
+
+    Optional<String> accessTokenOpt = jwtTokenService.extractCookie(request, "accessToken");
+    Optional<String> refreshTokenOpt = jwtTokenService.extractCookie(request, "refreshToken");
+
+    return accessTokenOpt
+        .map(token -> {
+          jwtTokenService.validateToken(token);
+          return Boolean.TRUE;
+        })
+        .or(() -> refreshTokenOpt.map(refreshToken -> {
+          jwtTokenService.validateToken(refreshToken);
+          throw new InvalidTokenException(JwtErrorCode.UNAUTHORIZED);
+        }))
+        .orElseThrow(() -> new InvalidTokenException(JwtErrorCode.UNAUTHORIZED));
+  }
+
+
+}

--- a/src/main/java/com/modureview/config/SecurityConfig.java
+++ b/src/main/java/com/modureview/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.modureview.config;
 
 import com.modureview.hanlder.SuccessHandler;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -10,10 +10,11 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor
 public class SecurityConfig {
 
-  private final SuccessHandler successHandler;
+  @Autowired
+  private SuccessHandler successHandler;
+
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/modureview/config/WebMvcConfig.java
+++ b/src/main/java/com/modureview/config/WebMvcConfig.java
@@ -1,0 +1,25 @@
+package com.modureview.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+  private final com.modureview.interceptor.JwtTokenInterceptor jwtTokenInterceptor;
+
+  public WebMvcConfig(com.modureview.interceptor.JwtTokenInterceptor jwtTokenInterceptor) {
+    this.jwtTokenInterceptor = jwtTokenInterceptor;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(jwtTokenInterceptor)
+        .excludePathPatterns(
+            "/user/oauth2/**",
+            "/token/refresh",
+            "/reviews/best"
+        );
+  }
+}

--- a/src/main/java/com/modureview/controller/LoginController.java
+++ b/src/main/java/com/modureview/controller/LoginController.java
@@ -1,0 +1,30 @@
+package com.modureview.controller;
+
+import com.modureview.service.JwtTokenService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LoginController {
+
+  private final JwtTokenService jwtTokenService;
+
+  @GetMapping("/login/result")
+  public ResponseEntity<String> tokenIssue(@RequestParam String email,
+      HttpServletResponse response) {
+    List<ResponseCookie> responseCookies = jwtTokenService.loginTokenIssue(email);
+
+    responseCookies.stream()
+        .forEach(cookie -> response.addHeader("Set-Cookie", cookie.toString()));
+
+    return ResponseEntity.ok("토큰이 발행 완료 : " + email);
+
+  }
+}

--- a/src/main/java/com/modureview/controller/LoginController.java
+++ b/src/main/java/com/modureview/controller/LoginController.java
@@ -24,7 +24,7 @@ public class LoginController {
     responseCookies.stream()
         .forEach(cookie -> response.addHeader("Set-Cookie", cookie.toString()));
 
-    return ResponseEntity.ok("토큰이 발행 완료 : " + email);
+    return ResponseEntity.ok("토큰 발행 완료 : " + email);
 
   }
 }

--- a/src/main/java/com/modureview/dto/response/ErrorResponse.java
+++ b/src/main/java/com/modureview/dto/response/ErrorResponse.java
@@ -1,0 +1,9 @@
+package com.modureview.dto.response;
+
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponse(
+    int code,
+    String message) {
+
+}

--- a/src/main/java/com/modureview/enums/JwtErrorCode.java
+++ b/src/main/java/com/modureview/enums/JwtErrorCode.java
@@ -1,0 +1,25 @@
+package com.modureview.enums;
+
+import org.springframework.http.HttpStatus;
+
+public enum JwtErrorCode {
+
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "유효하지 않은 사용자입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  JwtErrorCode(HttpStatus httpStatus, String message) {
+    this.httpStatus = httpStatus;
+    this.message = message;
+  }
+
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/com/modureview/exception/CustomException.java
+++ b/src/main/java/com/modureview/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.modureview.exception;
+
+import com.modureview.enums.JwtErrorCode;
+
+public class CustomException extends RuntimeException {
+  private final JwtErrorCode errorCode;
+
+  public CustomException(JwtErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public JwtErrorCode getErrorCode() {
+    return this.errorCode;
+  }
+  public String getErrorMessage() {
+    return errorCode.getMessage();
+  }
+}

--- a/src/main/java/com/modureview/exception/GlobalHandler.java
+++ b/src/main/java/com/modureview/exception/GlobalHandler.java
@@ -1,0 +1,25 @@
+package com.modureview.exception;
+
+import com.modureview.dto.response.ErrorResponse;
+import com.modureview.enums.JwtErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalHandler {
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+    JwtErrorCode errorCode = e.getErrorCode();
+
+    ErrorResponse response = new ErrorResponse(
+        errorCode.getHttpStatus().value(),
+        errorCode.getMessage()
+    );
+
+    return ResponseEntity
+        .status(errorCode.getHttpStatus())
+        .body(response);
+  }
+}

--- a/src/main/java/com/modureview/exception/jwtError/InvalidTokenException.java
+++ b/src/main/java/com/modureview/exception/jwtError/InvalidTokenException.java
@@ -1,0 +1,16 @@
+package com.modureview.exception.jwtError;
+
+import com.modureview.enums.JwtErrorCode;
+import com.modureview.exception.CustomException;
+
+public class InvalidTokenException extends CustomException {
+
+  public InvalidTokenException(JwtErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+}

--- a/src/main/java/com/modureview/exception/jwtError/TokenExpiredError.java
+++ b/src/main/java/com/modureview/exception/jwtError/TokenExpiredError.java
@@ -1,0 +1,16 @@
+package com.modureview.exception.jwtError;
+
+import com.modureview.enums.JwtErrorCode;
+import com.modureview.exception.CustomException;
+
+public class TokenExpiredError extends CustomException {
+
+  public TokenExpiredError(JwtErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+}

--- a/src/main/java/com/modureview/exception/jwtError/TokenExpiredException.java
+++ b/src/main/java/com/modureview/exception/jwtError/TokenExpiredException.java
@@ -1,0 +1,16 @@
+package com.modureview.exception.jwtError;
+
+import com.modureview.enums.JwtErrorCode;
+import com.modureview.exception.CustomException;
+
+public class TokenExpiredException extends CustomException {
+
+  public TokenExpiredException(JwtErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+}

--- a/src/main/java/com/modureview/service/JwtTokenService.java
+++ b/src/main/java/com/modureview/service/JwtTokenService.java
@@ -1,17 +1,20 @@
 package com.modureview.service;
 
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 @Service
 public class JwtTokenService {
 
-  private final String secretKey = "r8FkOq5W9XzRb7K1uDwYlH3gTjLmP2Na";
+  @Value("${jwt.secret}")
+  private String secretKey;
   private final Long accessTokenExpire = 60 * 60L;
   private final Long refreshTokenExpire = 30 * 24 * 60 * 60L;
 
@@ -35,6 +38,18 @@ public class JwtTokenService {
 
   public ResponseCookie createUserEmailCookie(String userEmail) {
     return createCookie("userEmail", userEmail, refreshTokenExpire, true);
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parserBuilder()
+          .setSigningKey(secretKey)
+          .build()
+          .parseClaimsJws(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      return false;
+    }
   }
 
   private String createJwtToken(String subject, Long expireSeconds, String key) {

--- a/src/main/resources/application-server.yaml
+++ b/src/main/resources/application-server.yaml
@@ -64,4 +64,4 @@ frontend:
   url: https://dev.modu-review.com:3000
 
 jwt:
-  secret=r8FkOq5W9XzRb7K1uDwYlH3gTjLmP2Na
+  secret: r8FkOq5W9XzRb7K1uDwYlH3gTjLmP2Na

--- a/src/main/resources/application-server.yaml
+++ b/src/main/resources/application-server.yaml
@@ -58,5 +58,10 @@ logging:
       modureview: DEBUG
     root: INFO
 
+#Consts
+
 frontend:
-  url: https://modu-review.com
+  url: https://dev.modu-review.com:3000
+
+jwt:
+  secret=r8FkOq5W9XzRb7K1uDwYlH3gTjLmP2Na

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,4 +64,4 @@ frontend:
   url: https://dev.modu-review.com:3000
 
 jwt:
-  secret=r8FkOq5W9XzRb7K1uDwYlH3gTjLmP2Na
+  secret: r8FkOq5W9XzRb7K1uDwYlH3gTjLmP2Na

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,5 +58,10 @@ logging:
       modureview: DEBUG
     root: INFO
 
+#Consts
+
 frontend:
-  url: https://modu-review.com
+  url: https://dev.modu-review.com:3000
+
+jwt:
+  secret=r8FkOq5W9XzRb7K1uDwYlH3gTjLmP2Na


### PR DESCRIPTION
## 제목
카카오 로그인 완료 후 jwt 토큰 검증 로직 추가

## 설명
모든 get, post요청에 대해 토큰을 검증하는 로직 Interceptor추가

1. 서버로 요청이 들어오면 Spring seurity -> Interceptor로 진입
2. Interceptor는 acccessToken, refreshToken검증 유효하지 않은 경우 401 에러 발생

## 변경 사항
<에러 처리 부분>
JwtErrorCode.java=====
error code를 정의한 enum

ErrorResponse.java=====
에러 resposne dto

CustomException.java=====
CustomException들이 상속받는 부모 클래스

InvalidTokenException.java=====
토큰이 유효하지 않은 경우 에러

TokenExpiredError.java=====
토큰이 만료된 경우 에러처리


<모든 요청에 대한 토큰 검증 로직>
JwtTokenInterceptor.java====
서버에 들어오는 모든 요청에 대해 토큰 검사하는 로직 추가

1. 액세스토큰 검사 -> 없으면 invalid 401에러
4. 리프레시 토큰 검사 -> 없으면 valid 401에러
5. 둘 다 없는 경우, 토큰이 유효하지 않은 경우-> invalid 에러

jwtTokenService.java=====
validateToken메서드 추가 public으로 사용하며 기존의 ParseAndTrhow private로직을 외부에서 사용하기 위함

WebMvcConfig.java=====
Interceptor지정, interceptor제외 링크
토큰 재발급(/token/refresh)
베스트후기 가져오기(/reviews/best)
로그인 링크(/user/oauth2/**)

## 추가 정보
Spring의 ControllerAdvice기능을 쓰기 위해 Filter대신 Interceptor사용

## 이슈
현재 refreshToken이 유효하면 정상 작동하도록 설계되어있음-> AccessToken이 유효하지 않은 경우에도 refresh이상 없으면 정상작동함
추후 hotfix/login로직에서 수정 예정