### PR TITLE
Feat/token refresh - AccessToken 재발급 로직

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 .settings
 .springBeans
 .sts4-cache
+.DS_Store
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
@@ -32,5 +33,9 @@ out/
 /dist/
 /nbdist/
 /.nb-gradle/
+
+#Spring
+/org/springframework
+
 
 

--- a/src/main/java/com/modureview/controller/LoginController.java
+++ b/src/main/java/com/modureview/controller/LoginController.java
@@ -1,6 +1,9 @@
 package com.modureview.controller;
 
+import com.modureview.enums.JwtErrorCode;
+import com.modureview.exception.jwtError.InvalidTokenException;
 import com.modureview.service.JwtTokenService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,5 +29,18 @@ public class LoginController {
 
     return ResponseEntity.ok("토큰 발행 완료 : " + email);
 
+  }
+
+  @GetMapping("/token/refresh")
+  public ResponseEntity<?> refresh(@RequestParam String token, HttpServletRequest request,
+      HttpServletResponse response) {
+    String refreshToken = jwtTokenService.extractCookie(request, "refreshToken")
+        .orElseThrow(() -> new InvalidTokenException(JwtErrorCode.UNAUTHORIZED));
+
+    ResponseCookie newAccessToken = jwtTokenService.reIssueAccessToken(token);
+
+    response.addHeader("Set-Cookie", newAccessToken.toString());
+
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/modureview/service/JwtTokenService.java
+++ b/src/main/java/com/modureview/service/JwtTokenService.java
@@ -54,6 +54,10 @@ public class JwtTokenService {
     parseAndThrow(token);
   }
 
+  public ResponseCookie reIssueAccessToken(String token){
+    return createAccessToken(token);
+  }
+
   private void parseAndThrow(String token) {
     try {
       Jwts.parserBuilder()


### PR DESCRIPTION
## 제목
액세스 토큰이 만료되었을 시 토큰 재발급 로직

## 설명
1.401에러가 발생 -> front에서 토큰 재발급 로직 요청(/token/refresh)
2.refreshToken검증
3. refreshToken에서 사용자 이메일 추출
4. 3의 추출한 이메일로 AccessToken재발급


## 변경사항
JwtTokenService.java=====
Token검증 public 서비스 추가
기존의 validate를 private에서 public으로 바꿔 클래스의 책임이 모호해지지 않도록 설정

LoginController.java=====
토큰 재발급하는 로직 추가

1. refreshToken검증
없거나 인증되지 않으면 401에러
2. 엑세스토큰 발급
3. 토큰 리턴

## 테스트 방법
프론트와 실제로 연동해보며 토큰 연동 확인
1. 액세스토큰 만료 -> 재발급 로직 정상작동 확인

## 추가 정보
이메일 추출 후 DB에서 값을 비교하는 로직 필요 
/hotfix/login 브랜치에서 수정 예정
