### PR TITLE
Hotfix/error code - ErrorCode 인터페이스화

### DIFF
--- a/src/main/java/com/modureview/enums/ErrorCode.java
+++ b/src/main/java/com/modureview/enums/ErrorCode.java
@@ -1,0 +1,10 @@
+package com.modureview.enums;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+  HttpStatus getHttpStatus();
+  String getMessage();
+
+
+}

--- a/src/main/java/com/modureview/enums/JwtErrorCode.java
+++ b/src/main/java/com/modureview/enums/JwtErrorCode.java
@@ -2,7 +2,7 @@ package com.modureview.enums;
 
 import org.springframework.http.HttpStatus;
 
-public enum JwtErrorCode {
+public enum JwtErrorCode implements ErrorCode {
 
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
   FORBIDDEN(HttpStatus.FORBIDDEN, "유효하지 않은 사용자입니다.");
@@ -15,10 +15,12 @@ public enum JwtErrorCode {
     this.message = message;
   }
 
+  @Override // 인터페이스 메서드 구현 명시
   public HttpStatus getHttpStatus() {
     return httpStatus;
   }
 
+  @Override // 인터페이스 메서드 구현 명시
   public String getMessage() {
     return message;
   }

--- a/src/main/java/com/modureview/exception/CustomException.java
+++ b/src/main/java/com/modureview/exception/CustomException.java
@@ -1,18 +1,22 @@
 package com.modureview.exception;
 
+import com.modureview.enums.ErrorCode;
 import com.modureview.enums.JwtErrorCode;
 
 public class CustomException extends RuntimeException {
-  private final JwtErrorCode errorCode;
+  private final ErrorCode errorCode;
 
-  public CustomException(JwtErrorCode errorCode) {
-    super(errorCode.getMessage());
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage()); // 부모 생성자에 메시지 전달
     this.errorCode = errorCode;
   }
 
-  public JwtErrorCode getErrorCode() {
+  public ErrorCode getErrorCode() {
     return this.errorCode;
   }
+
+
   public String getErrorMessage() {
     return errorCode.getMessage();
   }

--- a/src/main/java/com/modureview/exception/GlobalHandler.java
+++ b/src/main/java/com/modureview/exception/GlobalHandler.java
@@ -1,6 +1,7 @@
 package com.modureview.exception;
 
 import com.modureview.dto.response.ErrorResponse;
+import com.modureview.enums.ErrorCode;
 import com.modureview.enums.JwtErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,7 +12,7 @@ public class GlobalHandler {
 
   @ExceptionHandler(CustomException.class)
   public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-    JwtErrorCode errorCode = e.getErrorCode();
+    ErrorCode errorCode = e.getErrorCode();
 
     ErrorResponse response = new ErrorResponse(
         errorCode.getHttpStatus().value(),


### PR DESCRIPTION
## 제목
JwtErrorCode를 Interface로 구현한 ErrorCode를 상속받게 해서 다른 코드도 CustomExceptionLogic을 사용할 수 있게 하였습니다.

## 변경 사항
ErrorCode interface 추가
CustomLogicException , AdviceHandler에서 ErrorCode를 사용받을 수 있게 구현하였습니다.
JwtErrorCode가 ErrorCode를 상속받을 수 있게 바꾸었습니다.

## 설명


## 테스트 방법


## 성능

## 추가 정보


## 이슈