### PR TITLE
Feat/image save -> 게시글 작성중 사용자가 이미지를 업로드하는 로직

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.projectlombok:lombok:1.18.34'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     //JWT
@@ -45,17 +46,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
-    runtimeOnly 'com.mysql:mysql-connector-j'
 
-    //jwt Token
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
-    //aws S3
     implementation platform('software.amazon.awssdk:bom:2.25.3')
     implementation 'software.amazon.awssdk:s3'
-    implementation 'software.amazon.awssdk:s3-presigner'
     implementation 'software.amazon.awssdk:auth'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,16 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    //jwt Token
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //aws S3
+    implementation platform('software.amazon.awssdk:bom:2.25.3')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:s3-presigner'
+    implementation 'software.amazon.awssdk:auth'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modureview/config/AwsS3Config.java
+++ b/src/main/java/com/modureview/config/AwsS3Config.java
@@ -1,0 +1,33 @@
+package com.modureview.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+public class AwsS3Config {
+
+  private String bucket;
+  private String region;
+  private Credentials credentials;
+
+  @Getter
+  public static class Credentials {
+    private String accessKey;
+    private String secretKey;
+  }
+
+  public void setBucket(String bucket) {
+    this.bucket = bucket;
+  }
+
+  public void setRegion(String region) {
+    this.region = region;
+  }
+
+  public void setCredentials(Credentials credentials) {
+    this.credentials = credentials;
+  }
+}

--- a/src/main/java/com/modureview/config/AwsS3Config.java
+++ b/src/main/java/com/modureview/config/AwsS3Config.java
@@ -1,33 +1,24 @@
 package com.modureview.config;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 @Getter
-@Configuration
-@ConfigurationProperties(prefix = "cloud.aws.s3")
+@Setter
+@Component
+@ConfigurationProperties(prefix = "aws")
 public class AwsS3Config {
 
   private String bucket;
   private String region;
-  private Credentials credentials;
+  private Credentials credentials = new Credentials();  // ⬅️ null 방지 기본값
 
   @Getter
+  @Setter               // ⬅️  내부 클래스에도 Setter 추가
   public static class Credentials {
     private String accessKey;
     private String secretKey;
-  }
-
-  public void setBucket(String bucket) {
-    this.bucket = bucket;
-  }
-
-  public void setRegion(String region) {
-    this.region = region;
-  }
-
-  public void setCredentials(Credentials credentials) {
-    this.credentials = credentials;
   }
 }

--- a/src/main/java/com/modureview/controller/BoardController.java
+++ b/src/main/java/com/modureview/controller/BoardController.java
@@ -1,10 +1,16 @@
 package com.modureview.controller;
 
 import com.modureview.dto.BoardDetailResponse;
+import com.modureview.dto.request.PresignRequest;
 import com.modureview.service.BoardService;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,6 +24,18 @@ public class BoardController {
       @RequestParam Long board_id
   ){
     return ResponseEntity.ok().body(boardService.boardDetail(board_id));
+  }
+
+  @PostMapping("/presign")
+  public ResponseEntity<?> createImageInfo(@RequestBody PresignRequest fileType) {
+    String type = fileType.fileType();
+    String imageUuid = boardService.createImageID();
+    String presignedURL = boardService.createPresignedURL(imageUuid + "." + type);
+
+    Map<String, String> result = new HashMap<>();
+    result.put("uuid", imageUuid);
+    result.put("presignedUrl", presignedURL);
+    return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
 }

--- a/src/main/java/com/modureview/dto/request/PresignRequest.java
+++ b/src/main/java/com/modureview/dto/request/PresignRequest.java
@@ -1,0 +1,6 @@
+package com.modureview.dto.request;
+
+public record PresignRequest(String fileType) {
+
+}
+

--- a/src/main/java/com/modureview/enums/errors/ImageSaveErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/ImageSaveErrorCode.java
@@ -1,0 +1,30 @@
+package com.modureview.enums.errors;
+
+import com.modureview.enums.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ImageSaveErrorCode implements ErrorCode {
+  CAN_NOT_CREATE_PRESIGNED_URL(HttpStatus.INTERNAL_SERVER_ERROR,
+      "S3 PresignedURL을 생성할 수 없습니다."),
+
+  CAN_NOT_CREATE_UUID(HttpStatus.INTERNAL_SERVER_ERROR,
+      "이미지 uuid를 생성할 수 없습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  ImageSaveErrorCode(HttpStatus httpStatus, String message) {
+    this.httpStatus = httpStatus;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/com/modureview/exception/imageSaveError/CreatPresignedUrlError.java
+++ b/src/main/java/com/modureview/exception/imageSaveError/CreatPresignedUrlError.java
@@ -1,0 +1,17 @@
+package com.modureview.exception.imageSaveError;
+
+import com.modureview.enums.ErrorCode;
+import com.modureview.enums.errors.ImageSaveErrorCode;
+import com.modureview.exception.CustomException;
+
+public class CreatPresignedUrlError extends CustomException {
+
+  public CreatPresignedUrlError(ImageSaveErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+}

--- a/src/main/java/com/modureview/exception/imageSaveError/CreateUuidError.java
+++ b/src/main/java/com/modureview/exception/imageSaveError/CreateUuidError.java
@@ -1,0 +1,16 @@
+package com.modureview.exception.imageSaveError;
+
+import com.modureview.enums.ErrorCode;
+import com.modureview.exception.CustomException;
+
+public class CreateUuidError extends CustomException {
+
+  public CreateUuidError(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+}

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -1,20 +1,34 @@
 package com.modureview.service;
 
 
+import com.modureview.config.AwsS3Config;
 import com.modureview.dto.BoardDetailResponse;
 import com.modureview.entity.Board;
 import com.modureview.enums.errors.BoardErrorCode;
+import com.modureview.enums.errors.ImageSaveErrorCode;
 import com.modureview.exception.CustomException;
+import com.modureview.exception.imageSaveError.CreatPresignedUrlError;
+import com.modureview.exception.imageSaveError.CreateUuidError;
 import com.modureview.repository.BoardRepository;
 import jakarta.transaction.Transactional;
+import java.time.Duration;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class BoardService {
   private final BoardRepository boardRepository;
+  private final AwsS3Config awsS3Config;
 
   public BoardDetailResponse boardDetail(Long boardId) {
     Board findBoard = boardRepository.findById(boardId).orElseThrow(
@@ -33,4 +47,47 @@ public class BoardService {
 
     return response;
     }
+
+  public String createImageID() {
+    try {
+      return UUID.randomUUID().toString();
+    } catch (Exception e) {
+      throw new CreateUuidError(ImageSaveErrorCode.CAN_NOT_CREATE_UUID);
+    }
+  }
+
+  public String createPresignedURL(String key) {
+    try {
+      Region region = Region.of(awsS3Config.getRegion());
+
+      AwsBasicCredentials awsCreds = AwsBasicCredentials.create(
+          awsS3Config.getCredentials().getAccessKey(),
+          awsS3Config.getCredentials().getSecretKey()
+      );
+
+      PutObjectRequest objectRequest = PutObjectRequest.builder()
+          .bucket(awsS3Config.getBucket())
+          .key(key)
+          .contentType("image/png")
+          .build();
+
+      PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+          .signatureDuration(Duration.ofMinutes(10))
+          .putObjectRequest(objectRequest)
+          .build();
+
+      try (S3Presigner presigner = S3Presigner.builder()
+          .region(region)
+          .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+          .build()) {
+
+        PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(presignRequest);
+        return presignedRequest.url().toString();
+      }
+
+    } catch (Exception e) {
+      throw new CreatPresignedUrlError(ImageSaveErrorCode.CAN_NOT_CREATE_PRESIGNED_URL);
+    }
+  }
+
 }

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -14,6 +14,7 @@ import jakarta.transaction.Transactional;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class BoardService {
   private final BoardRepository boardRepository;
   private final AwsS3Config awsS3Config;
@@ -86,6 +88,7 @@ public class BoardService {
       }
 
     } catch (Exception e) {
+      log.info("presigned생성중 에러 : {}", e);
       throw new CreatPresignedUrlError(ImageSaveErrorCode.CAN_NOT_CREATE_PRESIGNED_URL);
     }
   }

--- a/src/main/resources/application-server.yaml
+++ b/src/main/resources/application-server.yaml
@@ -65,3 +65,10 @@ frontend:
 
 jwt:
   secret: eE5Z9q2Tr9vQnFc6sB8gD7xH0LpKm1NsUaXrYwZcGbHtJvMwQrAsXyZnVpCtEfGk
+
+aws:
+  region: ap-northeast-2
+  bucket: modus3
+  credentials:
+    access-key: ${ACCESS_KEY}
+    secret-key: ${SECRET_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,3 +65,10 @@ frontend:
 
 jwt:
   secret: eE5Z9q2Tr9vQnFc6sB8gD7xH0LpKm1NsUaXrYwZcGbHtJvMwQrAsXyZnVpCtEfGk
+
+aws:
+  region: ap-northeast-2
+  bucket: modus3
+  credentials:
+    access-key: ${ACCESS_KEY}
+    secret-key: ${SECRET_KEY}

--- a/src/test/java/com/modureview/service/BoardServiceTest.java
+++ b/src/test/java/com/modureview/service/BoardServiceTest.java
@@ -1,42 +1,50 @@
 package com.modureview.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.modureview.dto.BoardDetailResponse;
 import com.modureview.entity.Board;
 import com.modureview.entity.Category;
 import com.modureview.exception.CustomException;
 import com.modureview.repository.BoardRepository;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
-
-
-
-import java.util.Map;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
+@AutoConfigureMockMvc
 class BoardServiceTest {
   @Autowired
   private BoardService boardService;
+
   @Autowired
   private BoardRepository boardRepository;
+
   @Autowired
-  ObjectMapper objectMapper;
+  private ObjectMapper objectMapper;
 
-
+  @Autowired
+  private MockMvc mockMvc;
 
   @AfterEach
-  void cleanUp(){
+  void cleanUp() {
     boardRepository.deleteAll();
   }
 
@@ -118,5 +126,19 @@ class BoardServiceTest {
         .writeValueAsString(Map.of("error",ex.getClass().getSimpleName(),
             "message",ex.getMessage()));
     log.info("errorJson == {}", errorJson);
+  }
+
+  @DisplayName("S3 Presigned URL 생성 성공 테스트")
+  @Test
+  void createPresignedUrl_success() throws Exception {
+    // given
+    String keyJson = objectMapper.writeValueAsString(Map.of("fileType", "png"));
+
+    // when & then
+    mockMvc.perform(post("/presign")
+            .content(keyJson)
+            .contentType("application/json"))
+        .andExpect(status().isOk())
+        .andDo(print());
   }
 }


### PR DESCRIPTION
## 제목
게시글 저장중 사용자가 이미지를 올렸을 때 처리하는 로직

## 변경 사항
**1. application.yaml파일에 아마존 S3환경변수 추가 -> docker compose환경변수 사용**

**2. build.gradle에 Aws S3 설정 추가**

**3. 에러 관련 코드 생성 ImageSaveErrorCode**
CreatePresignedUrlError(Presigned발급시 발생하는 커스텀 에러), CreateUuidError(Uuid발급시 발생하는 커스텀 에러)

**4. BoardService** 
createImageId : 이미지 uuid생성
createPresignedURL(String key->생성된 Uuid+fileType ) : 생성한 이미지 uuid와 fileType을 받아 PresignedURL생성

**5. BoardController** 
service에서 생성한 uuid, presigend return

**6. Aws S3Config**
S3를 사용하기 위한 Config파일 추가

## 설명
사용자가 이미지를 올리면 /presign으로 post요청이 들어온다. 해당 요청에 따라서 S3 presignedURL과 이미지 uuid를 발급

![image](https://github.com/user-attachments/assets/0c41b92e-70e1-45b0-9e25-eb130ab8734e)

1. 컨트롤러에서 post요청이 들어온다. -> Controller
2. uuid, S3presigned를 생성한다. -> Service
3. service에서 받은 값을 Map으로 매핑해 front에게 return한다. 

## 테스트 방법
Junit 통합 테스트 수행 
mockMVC를 이용하여 post요청을 보내고 의도한 대로 동작하는지 확인

**BoardServiceTest**
Post요청을 보냈을 때 http상태 코드와 body내용 확인하는 방향으로 테스트 수행


## 추가 정보
S3키는 git에 올릴 수 없기때문에 docker compose파일에 환경변수로 지정하고 로컬 환경에서는 로컬 변수로 지정

## 이슈
Vault연결이 되었으나 환경변수를 가져오는 과정에서 데이터를 가져오지 못하는 현상 발생 -> docker-compose.yml에 환경변수를 지정하는 것으로 변경
