### PR TITLE
Feat/board save service -> 게시글 html 이미지 uuid추출 및 검사

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,11 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:auth'
 
-    // https://mvnrepository.com/artifact/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer
+    //owasp 화이트리스트 태그 검사
     implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20240325.1")
+
+    //jsoup이미지 링크 저장
+    implementation 'org.jsoup:jsoup:1.17.2'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,14 @@ dependencies {
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    //aws s3
     implementation platform('software.amazon.awssdk:bom:2.25.3')
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:auth'
+
+    // https://mvnrepository.com/artifact/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer
+    implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20240325.1")
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modureview/config/AwsS3Config.java
+++ b/src/main/java/com/modureview/config/AwsS3Config.java
@@ -13,10 +13,10 @@ public class AwsS3Config {
 
   private String bucket;
   private String region;
-  private Credentials credentials = new Credentials();  // ⬅️ null 방지 기본값
+  private Credentials credentials = new Credentials();
 
   @Getter
-  @Setter               // ⬅️  내부 클래스에도 Setter 추가
+  @Setter
   public static class Credentials {
     private String accessKey;
     private String secretKey;

--- a/src/main/java/com/modureview/controller/BoardController.java
+++ b/src/main/java/com/modureview/controller/BoardController.java
@@ -43,6 +43,7 @@ public class BoardController {
   public ResponseEntity<Map<String,String>> saveBoard(BoardSaveRequest boardSaveRequest) {
     boardService.htmlSanitizer(boardSaveRequest);
     boardService.saveBoard(boardSaveRequest);
+    boardService.extractImageInfo(boardSaveRequest);
 
     Map<String, String> response = Map.of("message", "게시글이 성공적으로 등록되었습니다.");
     return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/modureview/controller/BoardController.java
+++ b/src/main/java/com/modureview/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.modureview.controller;
 
 import com.modureview.dto.BoardDetailResponse;
+import com.modureview.dto.request.BoardSaveRequest;
 import com.modureview.dto.request.PresignRequest;
 import com.modureview.service.BoardService;
 import java.util.HashMap;
@@ -36,6 +37,15 @@ public class BoardController {
     result.put("uuid", imageUuid);
     result.put("presignedUrl", presignedURL);
     return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
+  @PostMapping("/review")
+  public ResponseEntity<Map<String,String>> saveBoard(BoardSaveRequest boardSaveRequest) {
+    boardService.htmlSanitizer(boardSaveRequest);
+    boardService.saveBoard(boardSaveRequest);
+
+    Map<String, String> response = Map.of("message", "게시글이 성공적으로 등록되었습니다.");
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
 }

--- a/src/main/java/com/modureview/dto/request/BoardSaveRequest.java
+++ b/src/main/java/com/modureview/dto/request/BoardSaveRequest.java
@@ -1,0 +1,5 @@
+package com.modureview.dto.request;
+
+public record BoardSaveRequest(String title, String content, String Category, String authorEmail) {
+
+}

--- a/src/main/java/com/modureview/dto/request/BoardSaveRequest.java
+++ b/src/main/java/com/modureview/dto/request/BoardSaveRequest.java
@@ -1,5 +1,5 @@
 package com.modureview.dto.request;
 
-public record BoardSaveRequest(String title, String content, String Category, String authorEmail) {
+public record BoardSaveRequest(String title, String content, String category, String authorEmail) {
 
 }

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -41,17 +41,17 @@ public class Board {
   @Column(columnDefinition = "TEXT")
   private String content;
 
-  private Integer commentsCount;
+  @Builder.Default
+  private Integer commentsCount = 0;
 
-  private Integer bookmarksCount;
+  @Builder.Default
+  private Integer bookmarksCount = 0;
 
   @Column( name = "created_at")
   private LocalDateTime createdAt;
 
   @Column( name = "modified_at")
   private LocalDateTime modifiedAt;
-
-
 
   @PrePersist
   protected void onCreate(){

--- a/src/main/java/com/modureview/enums/errors/BoardErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/BoardErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum BoardErrorCode implements ErrorCode {
   BOARD_ID_NOTFOUND(HttpStatus.NOT_FOUND,"게시글을 찾을 수 없습니다."),
   NOT_ALLOWED_HTML_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"잘못된 html입니다."),
-  BOARD_SAVE_ERROR(HttpStatus.CONFLICT,"데이터를 저장할 수 없습니다.");
+  BOARD_SAVE_ERROR(HttpStatus.CONFLICT,"데이터를 저장할 수 없습니다."),
+  IMG_SRC_EXTRACT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"html에서 이미지 추출중 에러가 발생했습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/modureview/enums/errors/BoardErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/BoardErrorCode.java
@@ -4,7 +4,9 @@ import com.modureview.enums.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum BoardErrorCode implements ErrorCode {
-  BOARD_ID_NOTFOUND(HttpStatus.NOT_FOUND,"게시글을 찾을 수 없습니다.");
+  BOARD_ID_NOTFOUND(HttpStatus.NOT_FOUND,"게시글을 찾을 수 없습니다."),
+  NOT_ALLOWED_HTML_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"잘못된 html입니다."),
+  BOARD_SAVE_ERROR(HttpStatus.CONFLICT,"데이터를 저장할 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/modureview/exception/BoardError/BoardSaveError.java
+++ b/src/main/java/com/modureview/exception/BoardError/BoardSaveError.java
@@ -1,0 +1,16 @@
+package com.modureview.exception.BoardError;
+
+import com.modureview.enums.ErrorCode;
+import com.modureview.exception.CustomException;
+
+public class BoardSaveError extends CustomException {
+
+  public BoardSaveError(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+}

--- a/src/main/java/com/modureview/exception/BoardError/ImageSrcExtractError.java
+++ b/src/main/java/com/modureview/exception/BoardError/ImageSrcExtractError.java
@@ -1,0 +1,18 @@
+package com.modureview.exception.BoardError;
+
+import com.modureview.enums.ErrorCode;
+import com.modureview.exception.CustomException;
+
+public class ImageSrcExtractError extends CustomException {
+
+  public ImageSrcExtractError(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+
+
+}

--- a/src/main/java/com/modureview/exception/BoardError/NotAllowedHtmlError.java
+++ b/src/main/java/com/modureview/exception/BoardError/NotAllowedHtmlError.java
@@ -1,0 +1,16 @@
+package com.modureview.exception.BoardError;
+
+import com.modureview.enums.ErrorCode;
+import com.modureview.exception.CustomException;
+
+public class NotAllowedHtmlError extends CustomException {
+
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+
+  public NotAllowedHtmlError(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -149,7 +149,8 @@ public class BoardService {
 
       if (src != null && !src.isBlank()) {
         String uuid = extractUuidFromUrl(src);
-        log.info("추출된 uuid {}", uuid);
+        //TODO
+        //추출한 uuid를 기반으로 board테이블에 cascade기반 업로드
       }
     }
   }

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -101,8 +101,7 @@ public class BoardService {
     }
   }
 
-  @Transactional
-  public void saveBoard(BoardSaveRequest request) {
+  public void htmlSanitizer(BoardSaveRequest request) {
     try {
       sanitizer.sanitize(request.content());
     } catch (Exception e) {
@@ -110,6 +109,10 @@ public class BoardService {
       throw new NotAllowedHtmlError(BoardErrorCode.NOT_ALLOWED_HTML_ERROR);
     }
 
+  }
+
+  @Transactional
+  public void saveBoard(BoardSaveRequest request) {
     Board board = Board.builder()
         .title(request.title())
         .content(request.content())

--- a/src/main/java/com/modureview/service/utils/HtmlSanitizerPolicy.java
+++ b/src/main/java/com/modureview/service/utils/HtmlSanitizerPolicy.java
@@ -1,0 +1,17 @@
+package com.modureview.service.utils;
+
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+
+public class HtmlSanitizerPolicy {
+
+  public static final PolicyFactory POLICY = new HtmlPolicyBuilder()
+      .allowElements("p", "ul", "ol", "li", "br", "strong", "em", "blockquote", "code", "pre")
+      .allowElements("a").allowAttributes("href").onElements("a")
+      .allowUrlProtocols("http", "https", "mailto")
+      .allowElements("img")
+      .allowElements("png")
+      .allowAttributes("src", "alt").onElements("img")
+      .allowUrlProtocols("http", "https", "data")
+      .toFactory();
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,3 +72,8 @@ aws:
   credentials:
     access-key: ${ACCESS_KEY}
     secret-key: ${SECRET_KEY}
+
+custom:
+  message:
+    image:
+      extract-fail: "no: image: can't extract image"


### PR DESCRIPTION
## 제목
게시글 html 이미지 uuid추출 및 검사

## 변경 사항
**build.gradle** 
owasp화이트 리스트 라이브러리 
uuid추출을 위한 jsoup라이브러리 추가

**AwsS3Config.java**
필요없는 주석 제거

**BoardController**
Controller에 게시글 저장 엔드포인트 지정
1. 게시글 점검
2. 이미지정보 추출
3. Board이미지 정보 DB에 저장
4. 게시글 저장
5. response리턴

**BoardSaveRequest**
front에서 받는 request를 record로 구성 

**Board.**
Board엔티티의 bookmarks, comments를 기본 0으로 구성

**BoardErrorCode**
보드에서 발생하는 에러코드 지정 
1. 이미지 추출 에러
2. 게시글 저장할 수 없음

**BoardSaveError**
BoardSaveError Custom에러 상속 처리

**ImageSrcExtractError**
이미지 저장할 때 발생하는 Custom에러 상속처리

**NotAllowedHtmlError**
허용되지 않은 html에러 Custom에러 상속 처리 

**HtmlSanitizerPolicy.java**
owasp허용 화이트리스트 지정


**Application.yaml**
실패 메세지 변수 지정 

**BoardService.**
1. html검사 
2. uuid추출로직 -> 저장은 따로 수행
3. Board게시글 저장 로직 구현

## 설명
owasp 라이브러리를 사용 -> html 태그 화이트리스트 검사
xss스크립트 공격을 막기 위함 

uuid추출 및 검사
board_image DB에 추가하기 위한 img html태그에 uuid추출

## 테스트 방법
파일 양 떄문에 Test는 다음 커밋에 짜기로 함

## 추가
추가로 구현해야하는 기능들이 있다.

1. Board게시글 저장 
2.BoardImage게시글 저장
3. 해당 로직 테스트코드 작성
