### PR TITLE
Feat/save board -> 게시글 저장 최종구현 

### DIFF
--- a/src/main/java/com/modureview/controller/BoardController.java
+++ b/src/main/java/com/modureview/controller/BoardController.java
@@ -5,6 +5,7 @@ import com.modureview.dto.request.BoardSaveRequest;
 import com.modureview.dto.request.PresignRequest;
 import com.modureview.service.BoardService;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,9 +43,11 @@ public class BoardController {
   }
 
   @PostMapping("/review")
-  public ResponseEntity<Map<String,String>> saveBoard(BoardSaveRequest boardSaveRequest) {
+  public ResponseEntity<Map<String, String>> saveBoard(
+      @RequestBody BoardSaveRequest boardSaveRequest) {
     boardService.htmlSanitizer(boardSaveRequest);
-    boardService.extractImageInfo(boardSaveRequest);
+    List<String> imageUuids = boardService.extractImageInfo(boardSaveRequest);
+    boardService.saveBoard(boardSaveRequest, imageUuids);
 
     Map<String, String> response = Map.of("message", "게시글이 성공적으로 등록되었습니다.");
     return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -1,5 +1,6 @@
 package com.modureview.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,10 +9,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,6 +45,8 @@ public class Board {
   @Column(columnDefinition = "TEXT")
   private String content;
 
+  private String thumbnail;
+
   @Builder.Default
   private Integer commentsCount = 0;
 
@@ -61,6 +67,15 @@ public class Board {
   @PreUpdate
   protected void onUpdate(){
     this.modifiedAt = LocalDateTime.now();
+  }
+
+  @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<BoardImage> images = new ArrayList<>();
+
+  public void addImage(BoardImage image) {
+    images.add(image);
+    image.setBoard(this);
   }
 
   @Builder

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -5,10 +5,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -35,6 +38,10 @@ public class Board {
   private Long id;
 
   private String title;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   private String authorEmail;
 
@@ -77,7 +84,7 @@ public class Board {
   }
 
   @Builder
-  public Board(String title, String authorEmail, Category category, String content, Integer commentsCount, Integer bookmarksCount) {
+  public Board(String title ,String authorEmail, Category category, String content, Integer commentsCount, Integer bookmarksCount) {
     this.title = title;
     this.authorEmail = authorEmail;
     this.category = category;

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -1,5 +1,6 @@
 package com.modureview.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,10 +9,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -61,6 +65,15 @@ public class Board {
   @PreUpdate
   protected void onUpdate(){
     this.modifiedAt = LocalDateTime.now();
+  }
+
+  @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<BoardImage> images = new ArrayList<>();
+
+  public void addImage(BoardImage image) {
+    images.add(image);
+    image.setBoard(this);
   }
 
   @Builder

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -5,10 +5,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -35,6 +38,10 @@ public class Board {
   private Long id;
 
   private String title;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   private String authorEmail;
 
@@ -79,7 +86,7 @@ public class Board {
   }
 
   @Builder
-  public Board(String title, String authorEmail, Category category, String content, Integer commentsCount, Integer bookmarksCount) {
+  public Board(String title ,String authorEmail, Category category, String content, Integer commentsCount, Integer bookmarksCount) {
     this.title = title;
     this.authorEmail = authorEmail;
     this.category = category;

--- a/src/main/java/com/modureview/entity/BoardImage.java
+++ b/src/main/java/com/modureview/entity/BoardImage.java
@@ -1,0 +1,43 @@
+package com.modureview.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "board_image")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class BoardImage {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String uuid;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "board_id")
+  private Board board;
+
+  public void setBoard(Board board) {
+    this.board = board;
+  }
+
+  public static BoardImage of(String uuid) {
+    return BoardImage.builder()
+        .uuid(uuid)
+        .build();
+  }
+}
+

--- a/src/main/java/com/modureview/entity/CategoryEntity.java
+++ b/src/main/java/com/modureview/entity/CategoryEntity.java
@@ -1,0 +1,21 @@
+package com.modureview.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "category")
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+public class CategoryEntity {
+  @Id
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, unique = true)
+  private Category categoryName;
+}
+

--- a/src/main/java/com/modureview/entity/User.java
+++ b/src/main/java/com/modureview/entity/User.java
@@ -2,13 +2,19 @@ package com.modureview.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,5 +51,8 @@ public class User {
   protected void onUpdate() {
     this.modifiedAt = LocalDateTime.now();
   }
+
+  @OneToMany(mappedBy = "user")
+  private List<Board> boards = new ArrayList<>();
 
 }

--- a/src/main/java/com/modureview/repository/CategoryRepository.java
+++ b/src/main/java/com/modureview/repository/CategoryRepository.java
@@ -1,0 +1,11 @@
+package com.modureview.repository;
+
+import com.modureview.entity.Category;
+import com.modureview.entity.CategoryEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
+
+  Optional<CategoryEntity> findByCategoryName(Category categoryName);
+}

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -7,6 +7,7 @@ import com.modureview.dto.request.BoardSaveRequest;
 import com.modureview.entity.Board;
 import com.modureview.entity.BoardImage;
 import com.modureview.entity.Category;
+import com.modureview.entity.User;
 import com.modureview.enums.errors.BoardErrorCode;
 import com.modureview.enums.errors.ImageSaveErrorCode;
 import com.modureview.exception.BoardError.BoardSaveError;
@@ -16,6 +17,7 @@ import com.modureview.exception.CustomException;
 import com.modureview.exception.imageSaveError.CreatPresignedUrlError;
 import com.modureview.exception.imageSaveError.CreateUuidError;
 import com.modureview.repository.BoardRepository;
+import com.modureview.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -44,6 +46,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 public class BoardService {
   private final BoardRepository boardRepository;
   private final AwsS3Config awsS3Config;
+  private final UserRepository userRepository;
 
   public BoardDetailResponse boardDetail(Long boardId) {
     Board findBoard = boardRepository.findById(boardId).orElseThrow(
@@ -117,9 +120,12 @@ public class BoardService {
 
   @Transactional
   public void saveBoard(BoardSaveRequest request, List<String> imageUuids) {
+    User user = userRepository.findByEmail(request.authorEmail()).get();
+
     Board board = Board.builder()
         .title(request.title())
         .content(request.content())
+        .user(user)
         .authorEmail(request.authorEmail())
         .category(Category.valueOf(request.category()))
         .build();

--- a/src/main/resources/application-server.yaml
+++ b/src/main/resources/application-server.yaml
@@ -72,3 +72,10 @@ aws:
   credentials:
     access-key: ${ACCESS_KEY}
     secret-key: ${SECRET_KEY}
+
+custom:
+  default:
+    image:
+      url: https://d1izijuzr22yly.cloudfront.net/no-image
+  image:
+    url:https://d1izijuzr22yly.cloudfront.net/

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,6 +74,9 @@ aws:
     secret-key: ${SECRET_KEY}
 
 custom:
-  message:
+  default:
     image:
-      extract-fail: "no: image: can't extract image"
+      url: https://d1izijuzr22yly.cloudfront.net/no-image
+  image:
+    url:https://d1izijuzr22yly.cloudfront.net/
+

--- a/src/test/java/com/modureview/unitTest/BoardServiceTest.java
+++ b/src/test/java/com/modureview/unitTest/BoardServiceTest.java
@@ -1,15 +1,28 @@
 package com.modureview.unitTest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+
 import com.modureview.config.AwsS3Config;
 import com.modureview.dto.request.BoardSaveRequest;
+import com.modureview.entity.Board;
+import com.modureview.entity.BoardImage;
+import com.modureview.entity.Category;
 import com.modureview.repository.BoardRepository;
 import com.modureview.service.BoardService;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@Slf4j
+@ExtendWith(MockitoExtension.class)
 public class BoardServiceTest {
 
   @InjectMocks
@@ -21,25 +34,63 @@ public class BoardServiceTest {
   @Mock
   private AwsS3Config awsS3Config;
 
-
-  @Spy
-  private BoardService spyBoardService; // for partial mocking
-
   @Test
+  @DisplayName("HTML에서 이미지 src로부터 UUID 리스트 추출")
   void extractImageInfo_extractsUuidsFromImgTags() {
     // given
-    String html = "<p>Some content</p><img src=\"https://d1izijuzr22yly.cloudfront.net/56b2dffa-428c-45d2-b8a3-80c8e2c9bb1b.png\" />";
-    BoardSaveRequest request = Mockito.mock(BoardSaveRequest.class);
-
-    BoardService service = Mockito.spy(new BoardService(boardRepository,
-        awsS3Config));
+    String html = """
+    <p>본문</p>
+    <img src="https://cdn.example.com/uuid1-aaaa.jpg" />
+    <img src="https://cdn.example.com/uuid2-bbbb.png" />
+  """;
+    BoardSaveRequest request = new BoardSaveRequest("제목", html, "car", "author@example.com");
 
     // when
-    Mockito.when(request.content()).thenReturn(html);
-    service.extractImageInfo(request);
+    List<String> uuids = boardService.extractImageInfo(request);
 
     // then
-    Mockito.verify(service).extractImageInfo(request);
+    assertEquals(2, uuids.size());
+    assertTrue(uuids.contains("uuid1-aaaa.jpg"));
+    assertTrue(uuids.contains("uuid2-bbbb.png"));
+  }
+
+  @Test
+  @DisplayName("게시글 저장 유닛 테스트")
+  public void boardSaveTest() {
+    //given
+    String html = """
+          <p>본문입니다</p>
+          <img src="https://cdn.example.com/uuid1-1111.jpg" />
+          <img src="https://cdn.example.com/uuid2-2222.png" />
+        """;
+
+    BoardSaveRequest request = new BoardSaveRequest(
+        "테스트 제목",
+        html,
+        "car",
+        "author@example.com"
+    );
+    //when
+    List<String> uuids = boardService.extractImageInfo(request);
+    boardService.saveBoard(request,uuids);
+
+    //then
+    ArgumentCaptor<Board> captor = ArgumentCaptor.forClass(Board.class);
+    verify(boardRepository).save(captor.capture());
+
+    Board savedBoard = captor.getValue();
+
+    assertEquals("테스트 제목", savedBoard.getTitle());
+    assertEquals(Category.car, savedBoard.getCategory());
+    assertEquals("author@example.com", savedBoard.getAuthorEmail());
+
+    List<BoardImage> images = savedBoard.getImages();
+    assertEquals(2, images.size());
+
+    List<String> savedImages = images.stream().map(BoardImage::getUuid).toList();
+    savedImages.forEach(uuid -> log.info("uuid = {}", uuid));
+    assertTrue(savedImages.contains("uuid1-1111.jpg"));
+    assertTrue(savedImages.contains("uuid2-2222.png"));
   }
 
 }

--- a/src/test/java/com/modureview/unitTest/BoardServiceTest.java
+++ b/src/test/java/com/modureview/unitTest/BoardServiceTest.java
@@ -3,15 +3,19 @@ package com.modureview.unitTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.modureview.config.AwsS3Config;
 import com.modureview.dto.request.BoardSaveRequest;
 import com.modureview.entity.Board;
 import com.modureview.entity.BoardImage;
 import com.modureview.entity.Category;
+import com.modureview.entity.User;
 import com.modureview.repository.BoardRepository;
+import com.modureview.repository.UserRepository;
 import com.modureview.service.BoardService;
 import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +36,9 @@ public class BoardServiceTest {
   private BoardRepository boardRepository;
 
   @Mock
+  private UserRepository userRepository;
+
+  @Mock
   private AwsS3Config awsS3Config;
 
   @Test
@@ -43,7 +50,7 @@ public class BoardServiceTest {
     <img src="https://cdn.example.com/uuid1-aaaa.jpg" />
     <img src="https://cdn.example.com/uuid2-bbbb.png" />
   """;
-    BoardSaveRequest request = new BoardSaveRequest("제목", html, "car", "author@example.com");
+    BoardSaveRequest request = new BoardSaveRequest("제목", html, "car", "testuser@example.com");
 
     // when
     List<String> uuids = boardService.extractImageInfo(request);
@@ -57,24 +64,32 @@ public class BoardServiceTest {
   @Test
   @DisplayName("게시글 저장 유닛 테스트")
   public void boardSaveTest() {
-    //given
+    // given
+    String email = "testuser@example.com";
+    User mockUser = User.builder()
+        .email(email)
+        .build();
+
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(mockUser));
+
     String html = """
-          <p>본문입니다</p>
-          <img src="https://cdn.example.com/uuid1-1111.jpg" />
-          <img src="https://cdn.example.com/uuid2-2222.png" />
-        """;
+        <p>본문입니다</p>
+        <img src="https://cdn.example.com/uuid1-1111.jpg" />
+        <img src="https://cdn.example.com/uuid2-2222.png" />
+      """;
 
     BoardSaveRequest request = new BoardSaveRequest(
         "테스트 제목",
         html,
         "car",
-        "author@example.com"
+        email
     );
-    //when
-    List<String> uuids = boardService.extractImageInfo(request);
-    boardService.saveBoard(request,uuids);
 
-    //then
+    // when
+    List<String> uuids = boardService.extractImageInfo(request);
+    boardService.saveBoard(request, uuids);
+
+    // then
     ArgumentCaptor<Board> captor = ArgumentCaptor.forClass(Board.class);
     verify(boardRepository).save(captor.capture());
 
@@ -82,13 +97,12 @@ public class BoardServiceTest {
 
     assertEquals("테스트 제목", savedBoard.getTitle());
     assertEquals(Category.car, savedBoard.getCategory());
-    assertEquals("author@example.com", savedBoard.getAuthorEmail());
+    assertEquals(email, savedBoard.getAuthorEmail());
 
     List<BoardImage> images = savedBoard.getImages();
     assertEquals(2, images.size());
 
     List<String> savedImages = images.stream().map(BoardImage::getUuid).toList();
-    savedImages.forEach(uuid -> log.info("uuid = {}", uuid));
     assertTrue(savedImages.contains("uuid1-1111.jpg"));
     assertTrue(savedImages.contains("uuid2-2222.png"));
   }


### PR DESCRIPTION
## 👀제목
게시글 저장기능 구현

## 🙋변경 사항
### 1. BoardController
게시글 저장 로직 서비스 로직 추가. 

### 2. Board
 BoardEntity에서 user와 board_image entity연동

### 3. BoardImage
Boardentity와 many to one 연동 

### 4.CategoryEntity
카테고리 entity생성

### 5. CategoryRepository
카테고리 jpa 연동을 위한 repository생성

### 6. BoardService
UserRepository에서 email에 따라서 userid를 가져와서 매핑, 이미지 uuid추출 후 board_image에 저장

### 7.  BoardServiceTest (unit)
service레이어 유닛테스트 진행

### 8. BoardServiceTest(통합)
controller 에서 mockMvc사용해 post메서드를 통해 통합 테스트 진행

## 💎설명
BoradController에서  Board를 저장하는 로직을 추가했다.

1. 유저 정보를 가져온다.
2. BoardEntity를 매핑한다.
3. 이미지 uuid를 추출한다. 
4. 이미지가 있는 경우 첫 번째 uuid를 썸네일로 없는 경우는 default 이미지 url로 설정한다. 
5. 해당 uuid와 Board정보를 함께 insert한다.

## 🔨테스트 방법
유닛테스트를 통한 서비스레이어 테스트 수행 

통합 테스트를 통한  테스트 수행 

**통합 테스트 수행 결과**

<img width="609" alt="image" src="https://github.com/user-attachments/assets/b5671cd1-36dd-468a-b4f4-a7da5315f6ae" />
<img width="495" alt="image" src="https://github.com/user-attachments/assets/f8d9ee26-18b3-4d45-aee5-665d9278bc98" />

thumnail이 있는 경우는 개인uuid가 그 외에는no-image가 들어가는 것을 확인할 수 있다. 

지정된 user로 이미지, board와 관련된 image가 board-image테이블에 삽입 되었다. 

## ⚙성능
현재 uuid의 수가 많으면 n번의 쿼리를 날리게된다. 추후 리팩토링이 필요할 듯 하다. 

## ℹ️추가 정보
cascade방식을 사용했기 때문에 각각 테이블의 의존성이 굉장히 크다.  이 점을 유의하면서 앞으로 로직을 구성해야할 것 같다. 

## ❌이슈
지연로딩의 한계**
- 게시글이 대량으로 삭제되면 연관된 이미지도 함께 삭제되기 때문에, 삭제 쿼리량이 급증하고 db부하가 우려된다. 따라서 일괄 삭제시 성능 테스트가 필요하다. 

**독립적인 이미지 관리의 한계**
이미지 업로드가 실패하거나 일부만 저장될 경우, 게시글 저장실패로 이어진다. -> 에러 처리 로직을 강화해야한다.

**게시글 수정/삭제 시 처리 고려**
- 게시글을 수정하는 경우, 기존 이미지 리스트를 어떻게 처리할지에 대한 정책 필요 
  전체삭제후 새로 추가/ 기존 유지 후 추가/ 일부만 삭제

