### PR TITLE
Error/save file-> 이미지 저장 파일 타입 추가

### DIFF
--- a/src/main/java/com/modureview/enums/errors/ImageSaveErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/ImageSaveErrorCode.java
@@ -8,7 +8,10 @@ public enum ImageSaveErrorCode implements ErrorCode {
       "S3 PresignedURL을 생성할 수 없습니다."),
 
   CAN_NOT_CREATE_UUID(HttpStatus.INTERNAL_SERVER_ERROR,
-      "이미지 uuid를 생성할 수 없습니다.");
+      "이미지 uuid를 생성할 수 없습니다."),
+
+  NOT_ALLOWED_FILE_TYPE(HttpStatus.INTERNAL_SERVER_ERROR,
+      "지정된 파일 형식이 아닙니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/modureview/exception/CustomException.java
+++ b/src/main/java/com/modureview/exception/CustomException.java
@@ -7,7 +7,7 @@ public class CustomException extends RuntimeException {
 
 
   public CustomException(ErrorCode errorCode) {
-    super(errorCode.getMessage()); // 부모 생성자에 메시지 전달
+    super(errorCode.getMessage());
     this.errorCode = errorCode;
   }
 

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -198,7 +198,6 @@ public class BoardService {
     if (key.endsWith(".png")) {
       return "image/png";
     }
-    // todo: 허용되지 않은 형식 에러 리턴 예정
-    return null;
+    throw new ImageSrcExtractError(BoardErrorCode.NOT_ALLOWED_HTML_ERROR);
   }
 }

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -90,7 +90,7 @@ public class BoardService {
           awsS3Config.getCredentials().getSecretKey()
       );
 
-      String contentType = resolveContentTypeByKey(key); // 아래 함수 정의 참조
+      String contentType = resolveContentTypeByKey(key);
 
       PutObjectRequest objectRequest = PutObjectRequest.builder()
           .bucket(awsS3Config.getBucket())

--- a/src/test/java/com/modureview/unitTest/BoardServiceTest.java
+++ b/src/test/java/com/modureview/unitTest/BoardServiceTest.java
@@ -2,6 +2,8 @@ package com.modureview.unitTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,18 +19,21 @@ import com.modureview.service.BoardService;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 public class BoardServiceTest {
 
+  @Spy
   @InjectMocks
   private BoardService boardService;
 
@@ -40,6 +45,16 @@ public class BoardServiceTest {
 
   @Mock
   private AwsS3Config awsS3Config;
+  @Mock
+  private AwsS3Config.Credentials credentials;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(awsS3Config.getBucket()).thenReturn("mock-bucket");
+    lenient().when(awsS3Config.getCredentials()).thenReturn(credentials);
+    lenient().when(credentials.getAccessKey()).thenReturn("mock-access");
+    lenient().when(credentials.getSecretKey()).thenReturn("mock-secret");
+  }
 
   @Test
   @DisplayName("HTML에서 이미지 src로부터 UUID 리스트 추출")
@@ -105,6 +120,27 @@ public class BoardServiceTest {
     List<String> savedImages = images.stream().map(BoardImage::getUuid).toList();
     assertTrue(savedImages.contains("uuid1-1111.jpg"));
     assertTrue(savedImages.contains("uuid2-2222.png"));
+  }
+
+  @Test
+  @DisplayName("Presigned URL is generated for PNG image")
+  void testPresignedUrlForPngImage() {
+    // given
+    String key = "sample.jpg";
+    String fakePresignedUrl = "https://fake-url.com/sample.jpeg";
+
+    doReturn(fakePresignedUrl)
+        .when(boardService)
+        .createPresignedURL(key);
+
+    // when
+    String result = boardService.createPresignedURL(key);
+
+    // print the result
+    log.info("📦 Presigned URL: " + result);
+
+    // then
+    assertEquals(fakePresignedUrl, result);
   }
 
 }


### PR DESCRIPTION
## 👀제목
게시글 저장시 jpeg, jpg 형식도 저장할 수 있도록 변경

## 🙋변경 사항
**BoardService.java**
허용되지 않은 이미지 형식 Exception throw

**ImageSaveErrorCode.java**
허용된 이미지 형식이 아닌경우 코드 추가

그 외 필요없는 주석 제거

## 💎설명
기존 png만 받던 로직에서 jpeg, jpg이미지도 받을 수 있도록 변경
jpeg는 jpg로 변경해 저장

## 🔨테스트 방법
Spring unit test를 사용해서 테스트를 수행함

@BeforeEach에 aws s3 stub 설정 
다른 테스트에서 사용하지 않는 경우 lenient()를 붙여 에러 발생 방지

미리 s3 가짜 객체를 생성하고 다른 테스트에서 해당 객체를 사용하지 않으면 에러 발생 -> 해당 에러를 lenient()로 사용하지 않는다면 무시해도 된다고 명시

추가로 프론트와 테스트후 성공하는 것 확인
<img width="755" alt="image" src="https://github.com/user-attachments/assets/3e3d73c5-3086-4a38-b198-1a54657d222e" />
