### PR TITLE
Hotfix

### DIFF
--- a/src/main/java/com/modureview/controller/SearchController.java
+++ b/src/main/java/com/modureview/controller/SearchController.java
@@ -41,7 +41,7 @@ public class SearchController {
         .toList();
     CustomPageResponse<BoardSearchResponse> SearchPage = new CustomPageResponse<>(
         listSearchBoard,
-        boardPage.getNumber(),
+        boardPage.getNumber() + 1,
         boardPage.getTotalPages()
     );
 

--- a/src/main/java/com/modureview/service/SearchService.java
+++ b/src/main/java/com/modureview/service/SearchService.java
@@ -38,7 +38,7 @@ public class SearchService {
       default -> sortCriteria = Sort.by(Direction.DESC, "createdAt");
     }
 
-    Pageable pageable = PageRequest.of(page, 6, sortCriteria);
+    Pageable pageable = PageRequest.of(page - 1, 6, sortCriteria);
     if (StringUtils.hasText(keyword)) {
       return searchRepository.findByKeyword(keyword, pageable);
     } else {


### PR DESCRIPTION
## 👀제목
Front와 맞추면서 변경점

## 🙋변경 사항
offset 버전의 페이지네이션에서 문제가 생겼습니다. 프론트에서는 초기 페이지에서 1을 주는 문제가 생겼습니다.

## 💎설명
Cursor방식과 차이가 있는 점은 초기값이 1인것이 boardId 가 1인 것과의 의미상의 중복이 생길 수 있었기 때문에 변경이 쉽지 않았지만 Page에 해당하는 것에 해당하였기에 백엔드에서 Page에서 임의로 -1 처리를 하였습니다.

## 🔨테스트 방법
실제 프론트 작업을 맞추어보았습니다.

## ⚙성능

## ℹ️추가 정보


## ❌이슈