### PR TITLE
Feat/Viewcomments

### DIFF
--- a/src/main/java/com/modureview/controller/CommentController.java
+++ b/src/main/java/com/modureview/controller/CommentController.java
@@ -1,0 +1,39 @@
+package com.modureview.controller;
+
+import com.modureview.dto.response.CommentDetailResponse;
+import com.modureview.dto.response.CustomPageResponse;
+import com.modureview.entity.Comment;
+import com.modureview.service.CommentService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @GetMapping("/reviews/{reviewId}/comments")
+  public ResponseEntity<CustomPageResponse<CommentDetailResponse>> getCommentList(
+      @PathVariable Long reviewId,
+      @RequestParam(name = "page", defaultValue = "0") int page
+  ) {
+    Page<Comment> commentPage = commentService.commentList(reviewId, page);
+    List<CommentDetailResponse> listComment = commentPage.getContent().stream()
+        .map(CommentDetailResponse::fromEntity)
+        .toList();
+    CustomPageResponse<CommentDetailResponse> commentPageResponse = new CustomPageResponse<>(
+        listComment,
+        commentPage.getNumber() + 1,
+        commentPage.getTotalPages()
+    );
+    return ResponseEntity.ok(commentPageResponse);
+  }
+
+}

--- a/src/main/java/com/modureview/dto/response/CommentDetailResponse.java
+++ b/src/main/java/com/modureview/dto/response/CommentDetailResponse.java
@@ -1,0 +1,24 @@
+package com.modureview.dto.response;
+
+import com.modureview.entity.Comment;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record CommentDetailResponse(
+    Long id,
+    String author,
+    String content,
+    LocalDateTime createdAt
+) {
+
+  public static CommentDetailResponse fromEntity(Comment comment) {
+    return CommentDetailResponse.builder()
+        .id(comment.getId())
+        .author(comment.getAuthor())
+        .content(comment.getContent())
+        .createdAt(comment.getCreatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/com/modureview/entity/Comment.java
+++ b/src/main/java/com/modureview/entity/Comment.java
@@ -1,0 +1,51 @@
+package com.modureview.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long boardId;
+
+  private String author;
+
+  private String content;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @Column(name = "modified_at")
+  private LocalDateTime modifiedAt;
+
+  @PrePersist
+  protected void onCreated() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdated() {
+    this.modifiedAt = LocalDateTime.now();
+  }
+
+
+}

--- a/src/main/java/com/modureview/repository/CommentRepository.java
+++ b/src/main/java/com/modureview/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.modureview.repository;
+
+
+import com.modureview.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+  Page<Comment> findByBoardId(Long boardId, Pageable pageable);
+}

--- a/src/main/java/com/modureview/service/CommentService.java
+++ b/src/main/java/com/modureview/service/CommentService.java
@@ -1,0 +1,26 @@
+package com.modureview.service;
+
+import com.modureview.entity.Comment;
+import com.modureview.repository.CommentRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+
+  public Page<Comment> commentList(Long boardId, int Page) {
+    Pageable pageable = PageRequest.of(Page - 1, 12, Sort.by(Direction.DESC, "createdAt"));
+
+    return commentRepository.findByBoardId(boardId, pageable);
+  }
+}

--- a/src/test/java/com/modureview/controller/CommentControllerTest.java
+++ b/src/test/java/com/modureview/controller/CommentControllerTest.java
@@ -1,0 +1,96 @@
+package com.modureview.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modureview.entity.Board;
+import com.modureview.entity.Comment;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.CommentRepository;
+import com.modureview.repository.UserRepository;
+import com.modureview.utill.TestUtil;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("h2")
+class CommentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private CommentRepository commentRepository;
+
+  @Autowired
+  private BoardRepository boardRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  private TestUtil testUtil;
+
+  @BeforeEach
+  void setUp() {
+    this.testUtil = new TestUtil();
+  }
+
+  @Test
+  @DisplayName("GET /reviews/{reviewId}/comments 성공")
+  void getBoardDetail_success() throws Exception {
+    Board board = testUtil.newBoard(userRepository.save(testUtil.newUser("test@test.com")));
+    Board newBoard = boardRepository.save(board);
+    Long newBoardId = newBoard.getId();
+    List<Comment> comments = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      comments.add(
+          Comment.builder()
+              .boardId(newBoardId)
+              .author(newBoard.getAuthorEmail())
+              .content("test content" + i)
+              .createdAt(LocalDateTime.now().minusMinutes(i))
+              .build());
+    }
+    commentRepository.saveAll(comments);
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/reviews/{reviewId}/comments", newBoardId)
+                .param("page", "1")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_000_000.0;
+    log.info("CommentControllerTest.getBoardDetail() 실행 시간: {} ns ({} ms)",
+        duration, String.format("%.3f", durationMs));
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+
+  }
+
+
+}

--- a/src/test/java/com/modureview/service/CommentServiceTest.java
+++ b/src/test/java/com/modureview/service/CommentServiceTest.java
@@ -1,0 +1,86 @@
+package com.modureview.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.modureview.entity.Comment;
+import com.modureview.repository.CommentRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+/**
+ * @ExtendWith(MockitoExtension.class): Mockito 프레임워크를 사용하여 단위 테스트를 진행합니다. 실제 스프링 컨텍스트를 로드하지 않아 통합
+ * 테스트보다 훨씬 가볍고 빠릅니다.
+ */
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+  // @InjectMocks: 테스트 대상인 CommentService 객체를 생성하고,
+  // @Mock으로 생성된 가짜(Mock) 객체를 주입합니다.
+  @InjectMocks
+  private CommentService commentService;
+
+  // @Mock: CommentService가 의존하는 CommentRepository의 가짜 객체를 생성합니다.
+  @Mock
+  private CommentRepository commentRepository;
+
+  // CommentService가 BoardService도 의존하고 있으므로, 해당 의존성도 Mock으로 생성해줍니다.
+  @Mock
+  private BoardService boardService;
+
+  @Test
+  @DisplayName("댓글 목록 조회 단위 테스트")
+  void commentListUnitTest() {
+    Long boardId = 1L;
+    int page = 1;
+
+    List<Comment> comments = IntStream.range(0, 10)
+        .mapToObj(i -> Comment.builder()
+            .id((long) i)
+            .boardId(boardId)
+            .author("test@test.com")
+            .content("test content " + i)
+            .createdAt(LocalDateTime.now().minusMinutes(i))
+            .build())
+        .collect(Collectors.toList());
+
+    Pageable pageable = PageRequest.of(page - 1, 15, Sort.by(Direction.DESC, "createdAt"));
+
+    Page<Comment> commentPage = new PageImpl<>(comments, pageable, comments.size());
+
+    when(commentRepository.findByBoardId(eq(boardId), any(Pageable.class)))
+        .thenReturn(commentPage);
+
+    Page<Comment> resultPage = commentService.commentList(boardId, page);
+
+    assertThat(resultPage).isNotNull();
+    assertThat(resultPage.getContent()).hasSize(10);
+    assertThat(resultPage.getContent().get(0).getContent()).isEqualTo("test content 0");
+
+    verify(commentRepository).findByBoardId(eq(boardId), eq(pageable));
+
+    System.out.println("✅ 단위 테스트 성공: CommentService가 Repository를 올바르게 호출하고 결과를 잘 반환했습니다.");
+    resultPage.getContent().forEach(c ->
+        System.out.println(
+            "내용: " + c.getContent() + ", 생성 시각: " + c.getCreatedAt()
+        )
+    );
+  }
+}


### PR DESCRIPTION
## 👀제목
댓글 조회 기능

## 🙋변경 사항
CommentController
- GET /reviews/{reviewId}/Comments 엔드포인트 추가
- reviewId 와 page 파라미터를 받아 댓글 목록 조회

CommentService
- commentList(Long boardId , int page) 메서드 추가
- PageRequest.of(page-1 , 12 , Sort.by(Direction.DESC , "createAt" )) 방식의 오프셋 기반 페이지네이션

CommentRepository
- findByBoardId(Long boardId , Pageable pageable) 메서드 정의

DTO , Entity
- Comment 엔티티에 createAt/modifiedAt 자동 셋팅 추가
- CommentDetailResponse DTO 와 CustomPageResponse<T> 응답 포멧 추가하였습니다.


테스트 코드
- CommentControllerTest(통합)
- @SpringBootTest , @AutoConfigureMockMvc , H2 프로필을 사용했습니다
- 댓글 10개 저장 후 GET /reviews/{id}comments?page =1 요청 

- CommentServiceTest(단위)
- Mockito 기반 findByBoardId 모킹
- 반환된 Page<Comment> 개수 및 내용 검증
- verify() 로 Repository 호출 파라미터 확인




## 💎설명
클라이언트에서 reviewId 와 페이지 번호를 넘기면 , 서비스 계층에서 MySQL/JPA 의 Pageable 오프셋 방식을 이용해 최신순 으로 댓글을 12개씩 짤라서 조회합니다. 조회된 Page<Comment>를 CommentDetailResponse로 반환한 뒤 , 전체 페이지 정보와 함께 CustomPageRequestResponse<List<CommentDetailResponse>> 방식으로 반환합니다.


## 🔨테스트 방법
<img width="1355" alt="image" src="https://github.com/user-attachments/assets/0651b644-40d7-4b22-85bf-d402a2dfef63" />
<img width="1355" alt="image" src="https://github.com/user-attachments/assets/aa278adb-4dd4-4c16-9c40-b11d269a7676" />


## ⚙성능
[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]

## ℹ️추가 정보
[Any additional information that reviewers should be aware of.]

## ❌이슈