### PR TITLE
Feat/best reviews - main에서 베스트후기 보여주기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     //jsoup이미지 링크 저장
     implementation 'org.jsoup:jsoup:1.17.2'
 
+    //Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modureview/controller/BestReviewCategoryController.java
+++ b/src/main/java/com/modureview/controller/BestReviewCategoryController.java
@@ -1,0 +1,31 @@
+package com.modureview.controller;
+
+import com.modureview.dto.BestReviewDto;
+import com.modureview.entity.Category;
+import com.modureview.service.BestReviewsService;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@AllArgsConstructor
+public class BestReviewCategoryController {
+
+  private final BestReviewsService bestReviewsService;
+
+  @GetMapping("/best/reviews")
+  public ResponseEntity<?> getBestReviews() {
+    Map<String, List<BestReviewDto>> allBestReviews = Stream.of(Category.values())
+        .collect(Collectors.toMap(
+            Category::name,
+            category -> bestReviewsService.getBestReviews(category.name())
+        ));
+
+    return ResponseEntity.ok(allBestReviews);
+  }
+}

--- a/src/main/java/com/modureview/controller/BestReviewController.java
+++ b/src/main/java/com/modureview/controller/BestReviewController.java
@@ -1,31 +1,50 @@
 package com.modureview.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.modureview.dto.BestReviewDto;
 import com.modureview.entity.Category;
 import com.modureview.service.BestReviewsService;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 @AllArgsConstructor
+@Slf4j
 public class BestReviewController {
 
   private final BestReviewsService bestReviewsService;
+  private final ObjectMapper objectMapper;
 
   @GetMapping("/best/reviews")
-  public ResponseEntity<?> getBestReviews() {
-    Map<String, List<BestReviewDto>> allBestReviews = Stream.of(Category.values())
-        .collect(Collectors.toMap(
-            Category::name,
-            category -> bestReviewsService.getBestReviews(category.name())
-        ));
+  public ResponseEntity<Map<String, Map<String, Object>>> getBestReviews() {
+    Map<String, Map<String, Object>> finalResponse =
+        Arrays.stream(Category.values())
+            .collect(Collectors.toMap(
+                Category::name,
+                category -> {
+                  List<BestReviewDto> reviews = bestReviewsService.getBestReviews(category.name());
+                  return Map.of(
+                      "count", reviews.size(),
+                      "reviews", reviews
+                  );
+                }
+            ));
 
-    return ResponseEntity.ok(allBestReviews);
+    try {
+      String prettyJsonResponse = objectMapper.writerWithDefaultPrettyPrinter()
+          .writeValueAsString(finalResponse);
+      log.info("최종 응답 데이터: \n{}", prettyJsonResponse);
+    } catch (JsonProcessingException e) {
+      log.error("최종 응답 객체 JSON 변환 실패", e);
+    }
+    return ResponseEntity.ok(finalResponse);
   }
 }

--- a/src/main/java/com/modureview/controller/BestReviewController.java
+++ b/src/main/java/com/modureview/controller/BestReviewController.java
@@ -23,7 +23,7 @@ public class BestReviewController {
   private final BestReviewsService bestReviewsService;
   private final ObjectMapper objectMapper;
 
-  @GetMapping("/best/reviews")
+  @GetMapping("/reviews/best")
   public ResponseEntity<Map<String, Map<String, Object>>> getBestReviews() {
     Map<String, Map<String, Object>> finalResponse =
         Arrays.stream(Category.values())

--- a/src/main/java/com/modureview/controller/BestReviewController.java
+++ b/src/main/java/com/modureview/controller/BestReviewController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 @AllArgsConstructor
-public class BestReviewCategoryController {
+public class BestReviewController {
 
   private final BestReviewsService bestReviewsService;
 

--- a/src/main/java/com/modureview/dto/BestReviewDto.java
+++ b/src/main/java/com/modureview/dto/BestReviewDto.java
@@ -1,0 +1,32 @@
+package com.modureview.dto;
+
+import com.modureview.entity.Board;
+import lombok.Builder;
+
+public record BestReviewDto(
+    Long boardId,
+    String title,
+    String author,
+    String category,
+    String contents,
+    int commentsCount,
+    int bookmarks,
+    String imageUrl
+) {
+
+  @Builder
+  public BestReviewDto {}
+
+  public static BestReviewDto from(Board board) {
+    return BestReviewDto.builder()
+        .boardId(board.getId())
+        .title(board.getTitle())
+        .author(board.getUser().getEmail())
+        .category(board.getCategory().name())
+        .contents(board.getContent())
+        .commentsCount(board.getCommentsCount())
+        .bookmarks(board.getBookmarksCount())
+        .imageUrl(board.getThumbnail())
+        .build();
+  }
+}

--- a/src/main/java/com/modureview/dto/BestReviewDto.java
+++ b/src/main/java/com/modureview/dto/BestReviewDto.java
@@ -1,32 +1,66 @@
 package com.modureview.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.modureview.entity.Board;
+import com.modureview.entity.BoardImage;
+import java.util.List;
 import lombok.Builder;
 
 public record BestReviewDto(
-    Long boardId,
+    @JsonProperty("boardId")
+    Long board_id,
+
+    @JsonProperty("title")
     String title,
+
+    @JsonProperty("author")
     String author,
+
+    @JsonProperty("category")
     String category,
+
+    @JsonProperty("thumbnail")
+    String thumbnail,
+
+    @JsonProperty("contents")
     String contents,
-    int commentsCount,
+
+    @JsonProperty("commentsCount")
+    int comments_count,
+
+    @JsonProperty("bookmarks")
     int bookmarks,
-    String imageUrl
+
+    @JsonProperty("image_url")
+    List<String> image_url,
+
+    @JsonProperty("view_count")
+    int viewCount
 ) {
 
   @Builder
   public BestReviewDto {}
-
   public static BestReviewDto from(Board board) {
-    return BestReviewDto.builder()
-        .boardId(board.getId())
-        .title(board.getTitle())
-        .author(board.getUser().getEmail())
-        .category(board.getCategory().name())
-        .contents(board.getContent())
-        .commentsCount(board.getCommentsCount())
-        .bookmarks(board.getBookmarksCount())
-        .imageUrl(board.getThumbnail())
-        .build();
+
+    List<String> imageUrls = board.getImages().stream()
+        .map(BoardImage::getFullImageUrl)
+        .toList();
+
+    return new BestReviewDto(
+        board.getId(),
+        board.getTitle(),
+        board.getUser().getEmail(),
+        board.getCategory().name(),
+        board.getThumbnail(),
+        board.getContent(),
+        board.getCommentsCount(),
+        board.getBookmarksCount(),
+        imageUrls,
+        board.getViewCount()
+    );
+  }
+
+  public int getHotScore() {
+    return (this.bookmarks * 4) + this.viewCount + (this.comments_count * 2);
   }
 }

--- a/src/main/java/com/modureview/dto/BestReviewDto.java
+++ b/src/main/java/com/modureview/dto/BestReviewDto.java
@@ -1,41 +1,20 @@
 package com.modureview.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.modureview.entity.Board;
 import com.modureview.entity.BoardImage;
 import java.util.List;
 import lombok.Builder;
 
 public record BestReviewDto(
-    @JsonProperty("boardId")
+
     Long board_id,
-
-    @JsonProperty("title")
     String title,
-
-    @JsonProperty("author")
     String author,
-
-    @JsonProperty("category")
     String category,
-
-    @JsonProperty("thumbnail")
-    String thumbnail,
-
-    @JsonProperty("contents")
-    String contents,
-
-    @JsonProperty("commentsCount")
+    String preview,
     int comments_count,
-
-    @JsonProperty("bookmarks")
     int bookmarks,
-
-    @JsonProperty("image_url")
-    List<String> image_url,
-
-    @JsonProperty("view_count")
-    int viewCount
+    String thumbnail
 ) {
 
   @Builder
@@ -51,16 +30,10 @@ public record BestReviewDto(
         board.getTitle(),
         board.getUser().getEmail(),
         board.getCategory().name(),
-        board.getThumbnail(),
-        board.getContent(),
+        board.getPreview(),
         board.getCommentsCount(),
         board.getBookmarksCount(),
-        imageUrls,
-        board.getViewCount()
+        board.getThumbnail()
     );
-  }
-
-  public int getHotScore() {
-    return (this.bookmarks * 4) + this.viewCount + (this.comments_count * 2);
   }
 }

--- a/src/main/java/com/modureview/dto/response/BestReviewCategoryResponse.java
+++ b/src/main/java/com/modureview/dto/response/BestReviewCategoryResponse.java
@@ -1,0 +1,14 @@
+package com.modureview.dto.response;
+
+import com.modureview.dto.BestReviewDto;
+import java.util.List;
+
+public record BestReviewCategoryResponse(
+    int count,
+    List<BestReviewDto> reviews
+) {
+
+  public static BestReviewCategoryResponse of(List<BestReviewDto> list) {
+    return new BestReviewCategoryResponse(list.size(), list);
+  }
+}

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -54,6 +54,8 @@ public class Board {
 
   private String thumbnail;
 
+  private String preview;
+
   @Builder.Default
   private Integer commentsCount = 0;
 

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -60,6 +60,9 @@ public class Board {
   @Builder.Default
   private Integer bookmarksCount = 0;
 
+  @Builder.Default
+  private Integer viewCount = 0;
+
   @Column( name = "created_at")
   private LocalDateTime createdAt;
 

--- a/src/main/java/com/modureview/entity/BoardImage.java
+++ b/src/main/java/com/modureview/entity/BoardImage.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 
 @Entity(name = "board_image")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,6 +20,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 public class BoardImage {
+
+  @Value("${custom.default.image.url}")
+  private String defaultImageUrl;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,6 +42,10 @@ public class BoardImage {
     return BoardImage.builder()
         .uuid(uuid)
         .build();
+  }
+
+  public String getFullImageUrl() {
+    return defaultImageUrl + this.uuid;
   }
 }
 

--- a/src/main/java/com/modureview/enums/errors/BestReviewErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/BestReviewErrorCode.java
@@ -1,0 +1,25 @@
+package com.modureview.enums.errors;
+
+import com.modureview.enums.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum BestReviewErrorCode implements ErrorCode {
+  JSON_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "JSON파싱중 에러가 발생했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  BestReviewErrorCode(HttpStatus httpStatus, String message) {
+    this.httpStatus = httpStatus;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/com/modureview/exception/bestReviewException/JsonParsingFromRedisException.java
+++ b/src/main/java/com/modureview/exception/bestReviewException/JsonParsingFromRedisException.java
@@ -1,0 +1,17 @@
+package com.modureview.exception.bestReviewException;
+
+import com.modureview.enums.ErrorCode;
+import com.modureview.exception.CustomException;
+
+public class JsonParsingFromRedisException extends CustomException {
+
+  public JsonParsingFromRedisException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  @Override
+  public ErrorCode getErrorCode() {
+    return super.getErrorCode();
+  }
+
+}

--- a/src/main/java/com/modureview/service/BestReviewsService.java
+++ b/src/main/java/com/modureview/service/BestReviewsService.java
@@ -1,0 +1,50 @@
+package com.modureview.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modureview.dto.BestReviewDto;
+import com.modureview.enums.errors.BestReviewErrorCode;
+import com.modureview.exception.bestReviewException.JsonParsingFromRedisException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.SequencedCollection;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class BestReviewsService {
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private final ObjectMapper objectMapper;
+
+  public List<BestReviewDto> getBestReviews(String category) {
+    String sortedSetKey = "best_reviews:" + category;
+    Set<String> boardIds = redisTemplate.opsForZSet().reverseRange(sortedSetKey, 0, 5);
+
+    if (boardIds == null || boardIds.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<BestReviewDto> bestReviews = new ArrayList<>();
+    for (String boardId : boardIds) {
+      String boardJson = redisTemplate.opsForValue().get("board:" + boardId);
+      if (boardJson != null) {
+        try {
+          BestReviewDto dto = objectMapper.readValue(boardJson, BestReviewDto.class);
+          bestReviews.add(dto);
+        } catch (JsonProcessingException e) {
+          log.error("BestReview Board정보 json파싱 실패: {}. JSON data: {}", boardId, boardJson, e);
+          throw new JsonParsingFromRedisException(BestReviewErrorCode.JSON_PROCESSING_ERROR);
+        }
+      }
+    }
+    return Collections.unmodifiableList(bestReviews);
+
+  }
+}

--- a/src/main/java/com/modureview/service/BestReviewsService.java
+++ b/src/main/java/com/modureview/service/BestReviewsService.java
@@ -8,7 +8,6 @@ import com.modureview.exception.bestReviewException.JsonParsingFromRedisExceptio
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.SequencedCollection;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/resources/application-server.yaml
+++ b/src/main/resources/application-server.yaml
@@ -8,6 +8,11 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  data:
+    redis:
+      host: redis
+      port: 6379
+
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     properties:
@@ -76,6 +81,6 @@ aws:
 custom:
   default:
     image:
-      url: https://d1izijuzr22yly.cloudfront.net/no-image
+      url: https://d1izijuzr22yly.cloudfront.net/no-thumbnail.png
   image:
     url:https://d1izijuzr22yly.cloudfront.net/

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,7 +76,7 @@ aws:
 custom:
   default:
     image:
-      url: https://d1izijuzr22yly.cloudfront.net/no-image
+      url: https://d1izijuzr22yly.cloudfront.net/no-thumbnail.png
   image:
     url:https://d1izijuzr22yly.cloudfront.net/
 

--- a/src/test/java/com/modureview/controller/BestReviewControllerTest.java
+++ b/src/test/java/com/modureview/controller/BestReviewControllerTest.java
@@ -20,7 +20,6 @@ class BestReviewControllerTest {
   public void testBestReviews() throws Exception {
 
     ResponseEntity<?> bestReviews = controller.getBestReviews();
-    log.info(bestReviews.getBody().toString());
 
   }
 }

--- a/src/test/java/com/modureview/controller/BestReviewControllerTest.java
+++ b/src/test/java/com/modureview/controller/BestReviewControllerTest.java
@@ -1,0 +1,26 @@
+package com.modureview.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest
+@Slf4j
+class BestReviewControllerTest {
+
+  @Autowired
+  BestReviewController controller;
+  @Test
+  @DisplayName("best/reviews통합 테스트 수행")
+  public void testBestReviews() throws Exception {
+
+    ResponseEntity<?> bestReviews = controller.getBestReviews();
+    log.info(bestReviews.getBody().toString());
+
+  }
+}

--- a/src/test/java/com/modureview/service/BestReviewsServiceTest.java
+++ b/src/test/java/com/modureview/service/BestReviewsServiceTest.java
@@ -1,0 +1,139 @@
+package com.modureview.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modureview.dto.BestReviewDto;
+import com.modureview.enums.errors.BestReviewErrorCode;
+import com.modureview.exception.bestReviewException.JsonParsingFromRedisException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
+
+@ExtendWith(MockitoExtension.class)
+class BestReviewsServiceTest {
+
+
+  @InjectMocks
+  private BestReviewsService bestReviewsService;
+
+  @Mock
+  private RedisTemplate<String, String> redisTemplate;
+
+  @Mock
+  private ObjectMapper objectMapper;
+
+  @Mock
+  private ZSetOperations<String, String> zSetOperations;
+  @Mock
+  private ValueOperations<String, String> valueOperations;
+
+  @BeforeEach
+  void setUp() {
+    when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+    lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+  }
+
+  @Test
+  @DisplayName("베스트 리뷰 조회 성공")
+  void getBestReviews_성공() throws JsonProcessingException {
+    // given
+    String category = "food";
+    String sortedSetKey = "best_reviews:" + category;
+
+    // Redis에서 가져올 가짜 데이터 설정
+    Set<String> boardIds = Set.of("101", "102");
+    String boardJson101 = "{\"id\":101, \"title\":\"맛집 리뷰\"}";
+    String boardJson102 = "{\"id\":102, \"title\":\"두번째 맛집 리뷰\"}";
+
+    // 2. 실제 DTO 생성
+    BestReviewDto dto101 = BestReviewDto.builder()
+        .boardId(101L)
+        .title("정말 맛있는 국밥집 후기")
+        .author("김리뷰")
+        .bookmarks(99)
+        .imageUrl("http://image.url/thumb1.jpg")
+        .build();
+
+    BestReviewDto dto102 = BestReviewDto.builder()
+        .boardId(102L)
+        .title("인생 파스타 맛집 찾았어요")
+        .author("이테스트")
+        .bookmarks(80)
+        .imageUrl("http://image.url/thumb2.jpg")
+        .build();
+
+    // 1. ZSet에서 boardId 목록을 가져오는 동작 Mocking
+    when(zSetOperations.reverseRange(sortedSetKey, 0, 5)).thenReturn(boardIds);
+
+    // 2. 각 boardId로 JSON 데이터를 가져오는 동작 Mocking
+    when(valueOperations.get("board:101")).thenReturn(boardJson101);
+    when(valueOperations.get("board:102")).thenReturn(boardJson102);
+
+    // 3. JSON을 DTO로 변환하는 동작 Mocking
+    when(objectMapper.readValue(boardJson101, BestReviewDto.class)).thenReturn(dto101);
+    when(objectMapper.readValue(boardJson102, BestReviewDto.class)).thenReturn(dto102);
+
+    // when
+    List<BestReviewDto> result = bestReviewsService.getBestReviews(category);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).hasSize(2);
+    assertThat(result).containsExactlyInAnyOrder(dto101, dto102);
+  }
+
+  @Test
+  @DisplayName("조회된 베스트 리뷰가 없을 때 빈 리스트 반환")
+  void getBestReviews_결과없음() {
+    // given
+    String category = "sports";
+    String sortedSetKey = "best_reviews:" + category;
+    when(zSetOperations.reverseRange(sortedSetKey, 0, 5)).thenReturn(Collections.emptySet());
+
+    // when
+    List<BestReviewDto> result = bestReviewsService.getBestReviews(category);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).isEmpty();
+  }
+  @Test
+  @DisplayName("Redis의 JSON 데이터 파싱 실패 시 예외 발생")
+  void getBestReviews_JSON파싱실패() throws JsonProcessingException, JsonProcessingException {
+    // given
+    String category = "car";
+    String sortedSetKey = "best_reviews:" + category;
+    Set<String> boardIds = Set.of("201");
+    String malformedJson = "{\"id\":201, \"title\":\"잘못된 JSON 형식"; // 닫는 괄호 없음
+
+    when(zSetOperations.reverseRange(sortedSetKey, 0, 5)).thenReturn(boardIds);
+    when(valueOperations.get("board:201")).thenReturn(malformedJson);
+
+    // objectMapper가 특정 JSON을 파싱할 때 예외를 던지도록 설정
+    when(objectMapper.readValue(malformedJson, BestReviewDto.class))
+        .thenThrow(new JsonParsingFromRedisException(BestReviewErrorCode.JSON_PROCESSING_ERROR)); // 또는 JsonProcessingException
+
+    // when & then
+    // getBestReviews(category)를 실행했을 때, JsonParsingFromRedisException 예외가 발생하는지 검증
+    assertThrows(JsonParsingFromRedisException.class, () -> {
+      bestReviewsService.getBestReviews(category);
+    });
+  }
+
+
+}

--- a/src/test/java/com/modureview/service/BestReviewsServiceTest.java
+++ b/src/test/java/com/modureview/service/BestReviewsServiceTest.java
@@ -66,7 +66,7 @@ class BestReviewsServiceTest {
         .title("정말 맛있는 국밥집 후기")
         .author("김리뷰")
         .bookmarks(99)
-        .image_url(List.of("/images/food/101_main.jpg", "/images/food/101_sub1.jpg"))
+        .thumbnail("/images/food/101_main.jpg")
         .build();
 
     BestReviewDto dto102 = BestReviewDto.builder()
@@ -74,7 +74,7 @@ class BestReviewsServiceTest {
         .title("인생 파스타 맛집 찾았어요")
         .author("이테스트")
         .bookmarks(80)
-        .image_url(List.of("/images/pasta/102_main.jpg"))
+        .thumbnail("/images/pasta/102_main.jpg")
         .build();
 
     // 1. ZSet에서 boardId 목록을 가져오는 동작 Mocking

--- a/src/test/java/com/modureview/service/BestReviewsServiceTest.java
+++ b/src/test/java/com/modureview/service/BestReviewsServiceTest.java
@@ -62,19 +62,19 @@ class BestReviewsServiceTest {
 
     // 2. 실제 DTO 생성
     BestReviewDto dto101 = BestReviewDto.builder()
-        .boardId(101L)
+        .board_id(101L)
         .title("정말 맛있는 국밥집 후기")
         .author("김리뷰")
         .bookmarks(99)
-        .imageUrl("http://image.url/thumb1.jpg")
+        .image_url(List.of("/images/food/101_main.jpg", "/images/food/101_sub1.jpg"))
         .build();
 
     BestReviewDto dto102 = BestReviewDto.builder()
-        .boardId(102L)
+        .board_id(102L)
         .title("인생 파스타 맛집 찾았어요")
         .author("이테스트")
         .bookmarks(80)
-        .imageUrl("http://image.url/thumb2.jpg")
+        .image_url(List.of("/images/pasta/102_main.jpg"))
         .build();
 
     // 1. ZSet에서 boardId 목록을 가져오는 동작 Mocking
@@ -124,12 +124,10 @@ class BestReviewsServiceTest {
     when(zSetOperations.reverseRange(sortedSetKey, 0, 5)).thenReturn(boardIds);
     when(valueOperations.get("board:201")).thenReturn(malformedJson);
 
-    // objectMapper가 특정 JSON을 파싱할 때 예외를 던지도록 설정
     when(objectMapper.readValue(malformedJson, BestReviewDto.class))
         .thenThrow(new JsonParsingFromRedisException(BestReviewErrorCode.JSON_PROCESSING_ERROR)); // 또는 JsonProcessingException
 
     // when & then
-    // getBestReviews(category)를 실행했을 때, JsonParsingFromRedisException 예외가 발생하는지 검증
     assertThrows(JsonParsingFromRedisException.class, () -> {
       bestReviewsService.getBestReviews(category);
     });


### PR DESCRIPTION
## 👀제목
Best후기 API리턴

## 🙋변경 사항
Redis의존성 추가
Best후기를 반환하는 Controller추가
Best후기 반환 DTO추가
Board Entity에 preview와 viewCount추가 
json parsing 커스텀 에러 추가 
BestReiew에러코드 추가
BestReview집계 결과를 가져오는 로직 추가
Controller통합테스트, Service unit 테스트 수행
thumbnail이 없는 경우 이미지 default경로 변경
Test수행

## 💎설명
1. Controller에 요청이 들어온다. 
2. Service로직에서 반환하는 로직을 수행한다. 
    "best_reviews:" + category 에 해당하는 키를 Redis에서 가져온다
    해당 키를 Json으로 파싱해서 board id를 가져온다.
    해당 id에 대한 정보를 Redis에서 조회한다.
3. Controller는 Service에서 받은 정보를 기반으로 response형식에 맞게 매핑한다.

## 🔨테스트 방법
Spring unit Test, 통합 테스트 수행 

**Spring unit Test**
1. 조회가 정상적으로 성공한 경우
2. Redis에 해당 카테고리 글이 없는 경우
3. Json파싱중 에러가 발생한 경우 

위의 세 가지 케이스를 수행했다.

**spring boot Test**
Controller에서 best/reviews endpoint로 요청이 들어왔을 때, 
실제로 JSON데이터를 반환하는지 확인


<img width="1308" alt="image" src="https://github.com/user-attachments/assets/0e2bc87b-c06b-4503-95dc-5c6ed3870197" />


## ❌이슈
Redis에서 데이터를 가져오지 못하는 경우에 재시도하는 로직 필요