### PR TITLE
fix(BoardPreview) : BoardSearchResponse

### DIFF
--- a/src/main/java/com/modureview/dto/response/BoardSearchResponse.java
+++ b/src/main/java/com/modureview/dto/response/BoardSearchResponse.java
@@ -13,7 +13,7 @@ public record BoardSearchResponse(
     Category category,
     String author,
     LocalDateTime create_At,
-    String content,
+    String preview,
     Integer comments_count,
     Integer bookmarks
 ) {
@@ -25,7 +25,7 @@ public record BoardSearchResponse(
         .category(board.getCategory())
         .author(board.getAuthorEmail())
         .create_At(board.getCreatedAt())
-        .content(board.getContent())
+        .preview(board.getPreview())
         .comments_count(board.getCommentsCount())
         .bookmarks(board.getBookmarksCount())
         .build();


### PR DESCRIPTION
## 👀제목
content -> preview 로 수정하였습니다.


## 🙋변경 사항
검색 환경에서 content를 응답에 넣지않고 preview를 넘겼습니다.

## 💎설명

검색 환경의 미리보기(검색환경 , 카테고리) 에서 본문 요청 대신 미리보기 같은 기능을 사용할 것 같아. content -> preview로 대체하였습니다.

## 🔨테스트 방법


## ⚙성능

## ℹ️추가 정보
[Any additional information that reviewers should be aware of.]

## ❌이슈