### PR TITLE
기존에 merge했던 사항이 viewComment로 들어가서 그대로 -> develop로 들어가는 겁니다..

### DIFF
--- a/src/main/java/com/modureview/controller/BookMarkController.java
+++ b/src/main/java/com/modureview/controller/BookMarkController.java
@@ -1,0 +1,27 @@
+package com.modureview.controller;
+
+import com.modureview.dto.response.BookMarkDetailResponse;
+import com.modureview.service.BookMarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BookMarkController {
+
+  private final BookMarkService bookMarkService;
+
+  @GetMapping("/reviews/{reviewId}/bookmarks")
+  public ResponseEntity<BookMarkDetailResponse> getBookMarkDetail(
+      @PathVariable Long reviewId,
+      @CookieValue(name = "email", required = false, defaultValue = "null") String email) {
+    BookMarkDetailResponse bookMarkDetailResponse = bookMarkService.bookMarkDetail(reviewId, email);
+    return ResponseEntity.ok(bookMarkDetailResponse);
+
+  }
+
+}

--- a/src/main/java/com/modureview/controller/CommentController.java
+++ b/src/main/java/com/modureview/controller/CommentController.java
@@ -1,0 +1,39 @@
+package com.modureview.controller;
+
+import com.modureview.dto.response.CommentDetailResponse;
+import com.modureview.dto.response.CustomPageResponse;
+import com.modureview.entity.Comment;
+import com.modureview.service.CommentService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @GetMapping("/reviews/{reviewId}/comments")
+  public ResponseEntity<CustomPageResponse<CommentDetailResponse>> getCommentList(
+      @PathVariable Long reviewId,
+      @RequestParam(name = "page", defaultValue = "0") int page
+  ) {
+    Page<Comment> commentPage = commentService.commentList(reviewId, page);
+    List<CommentDetailResponse> listComment = commentPage.getContent().stream()
+        .map(CommentDetailResponse::fromEntity)
+        .toList();
+    CustomPageResponse<CommentDetailResponse> commentPageResponse = new CustomPageResponse<>(
+        listComment,
+        commentPage.getNumber() + 1,
+        commentPage.getTotalPages()
+    );
+    return ResponseEntity.ok(commentPageResponse);
+  }
+
+}

--- a/src/main/java/com/modureview/dto/response/BookMarkDetailResponse.java
+++ b/src/main/java/com/modureview/dto/response/BookMarkDetailResponse.java
@@ -1,0 +1,18 @@
+package com.modureview.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BookMarkDetailResponse(
+    Integer bookmarks,
+    boolean hasBookmarked
+) {
+
+  public static BookMarkDetailResponse fromEntity(boolean hasBookMark, Integer bookmark_count) {
+    return BookMarkDetailResponse.builder()
+        .bookmarks(bookmark_count)
+        .hasBookmarked(hasBookMark)
+        .build();
+  }
+
+}

--- a/src/main/java/com/modureview/dto/response/CommentDetailResponse.java
+++ b/src/main/java/com/modureview/dto/response/CommentDetailResponse.java
@@ -1,0 +1,24 @@
+package com.modureview.dto.response;
+
+import com.modureview.entity.Comment;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record CommentDetailResponse(
+    Long id,
+    String author,
+    String content,
+    LocalDateTime createdAt
+) {
+
+  public static CommentDetailResponse fromEntity(Comment comment) {
+    return CommentDetailResponse.builder()
+        .id(comment.getId())
+        .author(comment.getAuthor())
+        .content(comment.getContent())
+        .createdAt(comment.getCreatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/com/modureview/entity/BookMark.java
+++ b/src/main/java/com/modureview/entity/BookMark.java
@@ -1,0 +1,28 @@
+package com.modureview.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookMark {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String email;
+
+  private Long boardId;
+
+  private boolean isBookmarked;
+}

--- a/src/main/java/com/modureview/entity/BookMark.java
+++ b/src/main/java/com/modureview/entity/BookMark.java
@@ -23,6 +23,5 @@ public class BookMark {
   private String email;
 
   private Long boardId;
-
-  private boolean isBookmarked;
+  
 }

--- a/src/main/java/com/modureview/entity/Comment.java
+++ b/src/main/java/com/modureview/entity/Comment.java
@@ -1,0 +1,51 @@
+package com.modureview.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long boardId;
+
+  private String author;
+
+  private String content;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @Column(name = "modified_at")
+  private LocalDateTime modifiedAt;
+
+  @PrePersist
+  protected void onCreated() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdated() {
+    this.modifiedAt = LocalDateTime.now();
+  }
+
+
+}

--- a/src/main/java/com/modureview/repository/BoardRepository.java
+++ b/src/main/java/com/modureview/repository/BoardRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
+  Board findByAuthorEmail(String mail);
 }

--- a/src/main/java/com/modureview/repository/BookMarkRepository.java
+++ b/src/main/java/com/modureview/repository/BookMarkRepository.java
@@ -1,0 +1,15 @@
+package com.modureview.repository;
+
+import com.modureview.entity.BookMark;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
+
+  @Query("SELECT b.isBookmarked FROM BookMark b WHERE b.boardId = :boardId AND b.email = :email")
+  Optional<Boolean> findIsBookmarkedByBoardIdAndEmail(@Param("boardId") Long boardId,
+      @Param("email") String email);
+
+}

--- a/src/main/java/com/modureview/repository/BookMarkRepository.java
+++ b/src/main/java/com/modureview/repository/BookMarkRepository.java
@@ -3,13 +3,9 @@ package com.modureview.repository;
 import com.modureview.entity.BookMark;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
-
-  @Query("SELECT b.isBookmarked FROM BookMark b WHERE b.boardId = :boardId AND b.email = :email")
-  Optional<Boolean> findIsBookmarkedByBoardIdAndEmail(@Param("boardId") Long boardId,
-      @Param("email") String email);
+  
+  Optional<Boolean> existsByBoardIdAndEmail(Long boardId, String email);
 
 }

--- a/src/main/java/com/modureview/repository/CommentRepository.java
+++ b/src/main/java/com/modureview/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.modureview.repository;
+
+
+import com.modureview.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+  Page<Comment> findByBoardId(Long boardId, Pageable pageable);
+}

--- a/src/main/java/com/modureview/service/BookMarkService.java
+++ b/src/main/java/com/modureview/service/BookMarkService.java
@@ -1,0 +1,44 @@
+package com.modureview.service;
+
+
+import com.modureview.dto.response.BookMarkDetailResponse;
+import com.modureview.entity.Board;
+import com.modureview.enums.errors.BoardErrorCode;
+import com.modureview.enums.errors.JwtErrorCode;
+import com.modureview.exception.CustomException;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.BookMarkRepository;
+import com.modureview.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class BookMarkService {
+
+  private final BookMarkRepository bookMarkRepository;
+  private final UserRepository userRepository;
+  private final BoardRepository boardRepository;
+
+  public BookMarkDetailResponse bookMarkDetail(Long reviewId, String email) {
+    log.info("reviewId == {}", reviewId);
+    log.info("email == {}", email);
+    Board targetBoard = boardRepository.findById(reviewId).orElseThrow(
+        () -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND)
+    );
+    if (!"null".equals(email)) {
+      userRepository.findByEmail(email).orElseThrow(
+          () -> new CustomException(JwtErrorCode.FORBIDDEN)
+      );
+      boolean targetBookmark = bookMarkRepository.findIsBookmarkedByBoardIdAndEmail(reviewId, email)
+          .orElse(false);
+      return BookMarkDetailResponse.fromEntity(targetBookmark, targetBoard.getBookmarksCount());
+    } else {
+      return BookMarkDetailResponse.fromEntity(false, targetBoard.getBookmarksCount());
+    }
+  }
+}

--- a/src/main/java/com/modureview/service/BookMarkService.java
+++ b/src/main/java/com/modureview/service/BookMarkService.java
@@ -34,9 +34,9 @@ public class BookMarkService {
       userRepository.findByEmail(email).orElseThrow(
           () -> new CustomException(JwtErrorCode.FORBIDDEN)
       );
-      boolean targetBookmark = bookMarkRepository.findIsBookmarkedByBoardIdAndEmail(reviewId, email)
+      bookMarkRepository.existsByBoardIdAndEmail(reviewId, email)
           .orElse(false);
-      return BookMarkDetailResponse.fromEntity(targetBookmark, targetBoard.getBookmarksCount());
+      return BookMarkDetailResponse.fromEntity(true, targetBoard.getBookmarksCount());
     } else {
       return BookMarkDetailResponse.fromEntity(false, targetBoard.getBookmarksCount());
     }

--- a/src/main/java/com/modureview/service/CommentService.java
+++ b/src/main/java/com/modureview/service/CommentService.java
@@ -1,0 +1,26 @@
+package com.modureview.service;
+
+import com.modureview.entity.Comment;
+import com.modureview.repository.CommentRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+
+  public Page<Comment> commentList(Long boardId, int Page) {
+    Pageable pageable = PageRequest.of(Page - 1, 12, Sort.by(Direction.DESC, "createdAt"));
+
+    return commentRepository.findByBoardId(boardId, pageable);
+  }
+}

--- a/src/test/java/com/modureview/controller/BookMarkControllerTest.java
+++ b/src/test/java/com/modureview/controller/BookMarkControllerTest.java
@@ -69,7 +69,6 @@ class BookMarkControllerTest {
           BookMark.builder()
               .email("test" + i + "@test.com")
               .boardId(board.getId())
-              .isBookmarked(true)
               .build()
       );
     }

--- a/src/test/java/com/modureview/controller/BookMarkControllerTest.java
+++ b/src/test/java/com/modureview/controller/BookMarkControllerTest.java
@@ -1,0 +1,125 @@
+package com.modureview.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modureview.entity.Board;
+import com.modureview.entity.BookMark;
+import com.modureview.entity.User;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.BookMarkRepository;
+import com.modureview.repository.UserRepository;
+import com.modureview.service.BookMarkService;
+import com.modureview.utill.TestUtil;
+import jakarta.servlet.http.Cookie;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("h2")
+class BookMarkControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private BookMarkService bookMarkService;
+
+  @Autowired
+  private BookMarkRepository bookMarkRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private BoardRepository boardRepository;
+
+  private TestUtil testUtil;
+
+
+  @BeforeEach
+  void setUp() {
+    this.testUtil = new TestUtil();
+    User user = userRepository.save(testUtil.newUser("test@test.com"));
+    User user1 = userRepository.save(testUtil.newUser("test1@test.com"));
+    Board board = boardRepository.save(testUtil.newBoard(user));
+    List<BookMark> bookMarks = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      bookMarks.add(
+          BookMark.builder()
+              .email("test" + i + "@test.com")
+              .boardId(board.getId())
+              .isBookmarked(true)
+              .build()
+      );
+    }
+    bookMarkRepository.saveAll(bookMarks);
+  }
+
+  @Test
+  @DisplayName("GET /reviews/{reviewId}/bookMarkController - isBookmarked : false")
+  void getBookmark_false() throws Exception {
+    Board byAuthorEmail = boardRepository.findByAuthorEmail("test@test.com");
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/reviews/{reviewId}/bookmarks", byAuthorEmail.getId())
+                .cookie(new Cookie("email", "test@test.com"))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_100_000.0;
+    log.info("BookMarkControllerTest.getBoardDetail()-false 실행 시간 : {} ns ({} ms)", duration,
+        String.format("%.3f", durationMs));
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+  }
+
+
+  @Test
+  @DisplayName("GET /reviews/{reviewId}/bookMarkController - isBookmarked : true")
+  void getBookmark_success() throws Exception {
+    Board byAuthorEmail = boardRepository.findByAuthorEmail("test@test.com");
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/reviews/{reviewId}/bookmarks", byAuthorEmail.getId())
+                .cookie(new Cookie("email", "test1@test.com"))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_100_000.0;
+    log.info("BookMarkControllerTest.getBoardDetail()-true 실행 시간 : {} ns ({} ms)", duration,
+        String.format("%.3f", durationMs));
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+  }
+}

--- a/src/test/java/com/modureview/controller/BookMarkControllerTest.java
+++ b/src/test/java/com/modureview/controller/BookMarkControllerTest.java
@@ -13,6 +13,7 @@ import com.modureview.repository.UserRepository;
 import com.modureview.service.BookMarkService;
 import com.modureview.utill.TestUtil;
 import jakarta.servlet.http.Cookie;
+import jakarta.transaction.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
+@Transactional
 @ActiveProfiles("h2")
 class BookMarkControllerTest {
 
@@ -59,7 +61,7 @@ class BookMarkControllerTest {
   void setUp() {
     this.testUtil = new TestUtil();
     User user = userRepository.save(testUtil.newUser("test@test.com"));
-    User user1 = userRepository.save(testUtil.newUser("test1@test.com"));
+    userRepository.save(testUtil.newUser("test1@test.com"));
     Board board = boardRepository.save(testUtil.newBoard(user));
     List<BookMark> bookMarks = new ArrayList<>();
     for (int i = 0; i < 10; i++) {

--- a/src/test/java/com/modureview/controller/CommentControllerTest.java
+++ b/src/test/java/com/modureview/controller/CommentControllerTest.java
@@ -1,0 +1,96 @@
+package com.modureview.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modureview.entity.Board;
+import com.modureview.entity.Comment;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.CommentRepository;
+import com.modureview.repository.UserRepository;
+import com.modureview.utill.TestUtil;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("h2")
+class CommentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private CommentRepository commentRepository;
+
+  @Autowired
+  private BoardRepository boardRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  private TestUtil testUtil;
+
+  @BeforeEach
+  void setUp() {
+    this.testUtil = new TestUtil();
+  }
+
+  @Test
+  @DisplayName("GET /reviews/{reviewId}/comments 성공")
+  void getBoardDetail_success() throws Exception {
+    Board board = testUtil.newBoard(userRepository.save(testUtil.newUser("test@test.com")));
+    Board newBoard = boardRepository.save(board);
+    Long newBoardId = newBoard.getId();
+    List<Comment> comments = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      comments.add(
+          Comment.builder()
+              .boardId(newBoardId)
+              .author(newBoard.getAuthorEmail())
+              .content("test content" + i)
+              .createdAt(LocalDateTime.now().minusMinutes(i))
+              .build());
+    }
+    commentRepository.saveAll(comments);
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/reviews/{reviewId}/comments", newBoardId)
+                .param("page", "1")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_000_000.0;
+    log.info("CommentControllerTest.getBoardDetail() 실행 시간: {} ns ({} ms)",
+        duration, String.format("%.3f", durationMs));
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+
+  }
+
+
+}

--- a/src/test/java/com/modureview/service/BookMarkServiceTest.java
+++ b/src/test/java/com/modureview/service/BookMarkServiceTest.java
@@ -1,0 +1,129 @@
+package com.modureview.service;
+
+import static com.modureview.enums.errors.BoardErrorCode.BOARD_ID_NOTFOUND;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.modureview.dto.response.BookMarkDetailResponse;
+import com.modureview.entity.Board;
+import com.modureview.entity.User;
+import com.modureview.enums.errors.JwtErrorCode;
+import com.modureview.exception.CustomException;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.BookMarkRepository;
+import com.modureview.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookMarkServiceTest {
+
+  @InjectMocks
+  private BookMarkService bookMarkService;
+
+  @Mock
+  private BookMarkRepository bookMarkRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private BoardRepository boardRepository;
+
+  @Test
+  @DisplayName("북마크 상세 조회 성공 - 로그인 유저 , 북마크 함")
+  void bookMarkDetail_Success_LoggedIn_Bookmarked() {
+    //given
+    Long reviewId = 1L;
+    String email = "test@example.com";
+    Board mockBoard = Board.builder().id(reviewId).bookmarksCount(10).build();
+    User mockUser = User.builder().email(email).build();
+
+    //Mock 객체의 행동 정의
+    when(boardRepository.findById(reviewId)).thenReturn(java.util.Optional.of(mockBoard));
+    when(userRepository.findByEmail(email)).thenReturn(java.util.Optional.of(mockUser));
+    when(bookMarkRepository.findIsBookmarkedByBoardIdAndEmail(reviewId, email)).thenReturn(
+        Optional.of(true));
+
+    //when
+    BookMarkDetailResponse response = bookMarkService.bookMarkDetail(reviewId, email);
+
+    //then
+    assertThat(response.hasBookmarked()).isTrue();
+    assertThat(response.bookmarks()).isEqualTo(10);
+
+    //Mock 객체의 메소드가 의도대로 호출되었는지 검증
+    verify(boardRepository, times(1)).findById(reviewId);
+    verify(userRepository, times(1)).findByEmail(email);
+    verify(bookMarkRepository, times(1)).findIsBookmarkedByBoardIdAndEmail(reviewId, email);
+  }
+
+  @Test
+  @DisplayName("북마크 상세 조회 성공 - 비로그인 유저")
+  void bookmarkDetail_Success_NotLoggedIn() {
+    //given
+    Long reviewId = 1L;
+    String email = "null";
+    Board mockBoard = Board.builder().id(reviewId).bookmarksCount(5).build();
+
+    when(boardRepository.findById(reviewId)).thenReturn(java.util.Optional.of(mockBoard));
+
+    //when
+    BookMarkDetailResponse response = bookMarkService.bookMarkDetail(reviewId, email);
+
+    //then
+    assertThat(response.hasBookmarked()).isFalse();
+    assertThat(response.bookmarks()).isEqualTo(5);
+
+    //비 로그인시 user,bookmark repository는 호출되지 말아야함.
+    verify(userRepository, never()).findByEmail(anyString());
+    verify(bookMarkRepository, never()).findIsBookmarkedByBoardIdAndEmail(anyLong(), anyString());
+  }
+
+  @Test
+  @DisplayName("북마크 상세 조회 실패 - 존재하지 않은 게시글 ID")
+  void bookMarkDetail_Fail_BoardNotFound() {
+    //given
+    Long reviewId = 999L;
+    String email = "test@example.com";
+
+    when(boardRepository.findById(reviewId)).thenReturn(Optional.empty());
+
+    //when&then
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      bookMarkService.bookMarkDetail(reviewId, email);
+    });
+
+    assertThat(exception.getErrorCode()).isEqualTo(BOARD_ID_NOTFOUND);
+  }
+
+  @Test
+  @DisplayName("북마크 상세 조회 실패 - 존재하지 않는 유저 (잘못된 토큰)")
+  void bookMarkDetail_Fail_UserNotFound() {
+    // given
+    Long reviewId = 1L;
+    String email = "unknown@example.com";
+    Board mockBoard = Board.builder().id(reviewId).bookmarksCount(10).build();
+
+    when(boardRepository.findById(reviewId)).thenReturn(Optional.of(mockBoard));
+    when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      bookMarkService.bookMarkDetail(reviewId, email);
+    });
+
+    assertThat(exception.getErrorCode()).isEqualTo(JwtErrorCode.FORBIDDEN);
+  }
+}

--- a/src/test/java/com/modureview/service/BookMarkServiceTest.java
+++ b/src/test/java/com/modureview/service/BookMarkServiceTest.java
@@ -53,7 +53,7 @@ class BookMarkServiceTest {
     //Mock 객체의 행동 정의
     when(boardRepository.findById(reviewId)).thenReturn(java.util.Optional.of(mockBoard));
     when(userRepository.findByEmail(email)).thenReturn(java.util.Optional.of(mockUser));
-    when(bookMarkRepository.findIsBookmarkedByBoardIdAndEmail(reviewId, email)).thenReturn(
+    when(bookMarkRepository.existsByBoardIdAndEmail(reviewId, email)).thenReturn(
         Optional.of(true));
 
     //when
@@ -66,7 +66,7 @@ class BookMarkServiceTest {
     //Mock 객체의 메소드가 의도대로 호출되었는지 검증
     verify(boardRepository, times(1)).findById(reviewId);
     verify(userRepository, times(1)).findByEmail(email);
-    verify(bookMarkRepository, times(1)).findIsBookmarkedByBoardIdAndEmail(reviewId, email);
+    verify(bookMarkRepository, times(1)).existsByBoardIdAndEmail(reviewId, email);
   }
 
   @Test
@@ -88,7 +88,7 @@ class BookMarkServiceTest {
 
     //비 로그인시 user,bookmark repository는 호출되지 말아야함.
     verify(userRepository, never()).findByEmail(anyString());
-    verify(bookMarkRepository, never()).findIsBookmarkedByBoardIdAndEmail(anyLong(), anyString());
+    verify(bookMarkRepository, never()).existsByBoardIdAndEmail(anyLong(), anyString());
   }
 
   @Test

--- a/src/test/java/com/modureview/service/CommentServiceTest.java
+++ b/src/test/java/com/modureview/service/CommentServiceTest.java
@@ -1,0 +1,86 @@
+package com.modureview.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.modureview.entity.Comment;
+import com.modureview.repository.CommentRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+/**
+ * @ExtendWith(MockitoExtension.class): Mockito 프레임워크를 사용하여 단위 테스트를 진행합니다. 실제 스프링 컨텍스트를 로드하지 않아 통합
+ * 테스트보다 훨씬 가볍고 빠릅니다.
+ */
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+  // @InjectMocks: 테스트 대상인 CommentService 객체를 생성하고,
+  // @Mock으로 생성된 가짜(Mock) 객체를 주입합니다.
+  @InjectMocks
+  private CommentService commentService;
+
+  // @Mock: CommentService가 의존하는 CommentRepository의 가짜 객체를 생성합니다.
+  @Mock
+  private CommentRepository commentRepository;
+
+  // CommentService가 BoardService도 의존하고 있으므로, 해당 의존성도 Mock으로 생성해줍니다.
+  @Mock
+  private BoardService boardService;
+
+  @Test
+  @DisplayName("댓글 목록 조회 단위 테스트")
+  void commentListUnitTest() {
+    Long boardId = 1L;
+    int page = 1;
+
+    List<Comment> comments = IntStream.range(0, 10)
+        .mapToObj(i -> Comment.builder()
+            .id((long) i)
+            .boardId(boardId)
+            .author("test@test.com")
+            .content("test content " + i)
+            .createdAt(LocalDateTime.now().minusMinutes(i))
+            .build())
+        .collect(Collectors.toList());
+
+    Pageable pageable = PageRequest.of(page - 1, 15, Sort.by(Direction.DESC, "createdAt"));
+
+    Page<Comment> commentPage = new PageImpl<>(comments, pageable, comments.size());
+
+    when(commentRepository.findByBoardId(eq(boardId), any(Pageable.class)))
+        .thenReturn(commentPage);
+
+    Page<Comment> resultPage = commentService.commentList(boardId, page);
+
+    assertThat(resultPage).isNotNull();
+    assertThat(resultPage.getContent()).hasSize(10);
+    assertThat(resultPage.getContent().get(0).getContent()).isEqualTo("test content 0");
+
+    verify(commentRepository).findByBoardId(eq(boardId), eq(pageable));
+
+    System.out.println("✅ 단위 테스트 성공: CommentService가 Repository를 올바르게 호출하고 결과를 잘 반환했습니다.");
+    resultPage.getContent().forEach(c ->
+        System.out.println(
+            "내용: " + c.getContent() + ", 생성 시각: " + c.getCreatedAt()
+        )
+    );
+  }
+}


### PR DESCRIPTION
## 👀제목
댓글 및 북마크 조회 기능 추가

## 🙋변경 사항
- 댓글 조회 기능 추가
- CommentController에 GET /reviews/{reviewId}/comments 엔드포인트 추가  ￼
- CommentService에 페이지네이션(12개/페이지, 최신순) 적용  ￼
- CommentRepository에 findByBoardId(Long, Pageable) 메서드 정의  ￼
- CommentDetailResponse DTO 추가 및 엔티티 변환 로직 구현  ￼
- CommentControllerTest, CommentServiceTest 단위/통합 테스트 추가  ￼
- 북마크 조회 기능 추가
- BookMarkController에 GET /reviews/{reviewId}/bookmarks 엔드포인트 추가  ￼
- BookMarkService에서 로그인 여부에 따른 조회 로직 분기 처리 (쿠키 email 활용)  ￼
- BookMarkRepository에 existsByBoardIdAndEmail(Long, String) 메서드 정의  ￼
- BookMarkDetailResponse DTO 추가 및 엔티티 변환 로직 구현  ￼
- BookMarkControllerTest, BookMarkServiceTest 단위/통합 테스트 추가  ￼

## 💎설명
- 요구사항: 특정 리뷰 글에 대해
- 1.사용자(로그인/비로그인)별 북마크 상태를 확인
- 2.페이지 단위(12개씩)의 댓글 목록 조회

- 구현 배경:
사용자 경험 향상을 위해 댓글과 북마크 상태를 API 차원에서 제공
프론트엔드에서 간단한 호출만으로도 UI 렌더링 가능하도록 설계

## 🔨테스트 방법
[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

## ⚙성능
[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]

## ℹ️추가 정보
[Any additional information that reviewers should be aware of.]

## ❌이슈