### PR TITLE
Feat/my page book mark

### DIFF
--- a/src/main/java/com/modureview/controller/MyPageController.java
+++ b/src/main/java/com/modureview/controller/MyPageController.java
@@ -38,5 +38,20 @@ public class MyPageController {
     return ResponseEntity.ok(myPage);
   }
 
-
+  @GetMapping("/users/me/bookmarks")
+  public ResponseEntity<CustomPageResponse<BoardSearchResponse>> getBookMarkBoards(
+      @CookieValue(name = "userEmail") String email,
+      @RequestParam(name = "page", defaultValue = "0") int page
+  ) {
+    Page<Board> boardMyPage = myPageService.myPageBookmark(email, page);
+    List<BoardSearchResponse> listMyPage = boardMyPage.getContent().stream()
+        .map(BoardSearchResponse::fromEntity)
+        .toList();
+    CustomPageResponse<BoardSearchResponse> myPage = new CustomPageResponse<>(
+        listMyPage,
+        boardMyPage.getNumber() + 1,
+        boardMyPage.getTotalPages()
+    );
+    return ResponseEntity.ok(myPage);
+  }
 }

--- a/src/main/java/com/modureview/entity/BookMark.java
+++ b/src/main/java/com/modureview/entity/BookMark.java
@@ -1,0 +1,48 @@
+package com.modureview.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookMark {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String email;
+
+  private Long boardId;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @Column(name = "modified_at")
+  private LocalDateTime modifiedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.modifiedAt = LocalDateTime.now();
+  }
+
+}

--- a/src/main/java/com/modureview/repository/MyPageBookMarkRepository.java
+++ b/src/main/java/com/modureview/repository/MyPageBookMarkRepository.java
@@ -1,0 +1,19 @@
+package com.modureview.repository;
+
+import com.modureview.entity.BookMark;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MyPageBookMarkRepository extends JpaRepository<BookMark, Long> {
+
+  @Query(
+      value = "SELECT bm.boardId "
+          + "FROM BookMark bm "
+          + "WHERE bm.email = :email"
+  )
+  Page<Long> findBookMarksByEmail(String email, Pageable pageable);
+
+
+}

--- a/src/main/java/com/modureview/service/MyPageService.java
+++ b/src/main/java/com/modureview/service/MyPageService.java
@@ -3,12 +3,19 @@ package com.modureview.service;
 import com.modureview.entity.Board;
 import com.modureview.enums.errors.UserErrorCode;
 import com.modureview.exception.CustomException;
+import com.modureview.repository.MyPageBookMarkRepository;
 import com.modureview.repository.MyPageRepository;
 import com.modureview.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -23,6 +30,7 @@ public class MyPageService {
 
   private final UserRepository userRepository;
   private final MyPageRepository myPageRepository;
+  private final MyPageBookMarkRepository myPageBookMarkRepository;
 
   public Page<Board> myPageBoard(String email, int page) {
     Sort sortCriteria = Sort.by(Direction.DESC, "createdAt");
@@ -33,4 +41,27 @@ public class MyPageService {
     }
     throw new CustomException(UserErrorCode.USER_NOT_FOUND);
   }
+
+  public Page<Board> myPageBookmark(String email, int page) {
+    Sort sortCriteria = Sort.by(Direction.DESC, "createdAt");
+    Pageable pageable = PageRequest.of(page - 1, 6, sortCriteria);
+    if (userRepository.findByEmail(email).isEmpty()) {
+      throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+    }
+
+    Page<Long> boardIdPage = myPageBookMarkRepository.findBookMarksByEmail(email, pageable);
+    List<Long> boardIds = boardIdPage.getContent();
+    List<Board> boardList = myPageRepository.findAllById(boardIds);
+    Map<Long, Board> boardMap = boardList.stream()
+        .collect(Collectors.toMap(Board::getId, Function.identity()));
+    List<Board> sortedBoards = boardIds.stream()
+        .map(boardMap::get)
+        .filter(Objects::nonNull)
+        .toList();
+    return new PageImpl<>(sortedBoards, pageable, boardIdPage.getTotalElements());
+
+
+  }
+
+
 }

--- a/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
+++ b/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
@@ -1,0 +1,129 @@
+package com.modureview.service;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.modureview.entity.Board;
+import com.modureview.entity.Category;
+import com.modureview.entity.User;
+import com.modureview.exception.CustomException;
+import com.modureview.repository.MyPageBookMarkRepository;
+import com.modureview.repository.MyPageRepository;
+import com.modureview.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+class MyPageServiceUnitTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private MyPageBookMarkRepository myPageBookMarkRepository;
+
+  @Mock
+  private MyPageRepository myPageRepository;
+
+  @InjectMocks
+  private MyPageService service;
+
+  @Test
+  @DisplayName("존재하지 않는 사용자가 북마크 페이지 조회시 USER_NOT_FOUND 예외 발생")
+  void testMyPageBookmark_UserNotFound() {
+    String email = "nouser@example.com";
+    int page = 1;
+
+    when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+    CustomException ex = assertThrows(CustomException.class,
+        () -> service.myPageBookmark(email, page));
+
+    log.info("ex.getErrorCode() == {}", ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("존재하는 사용자가 북마크 페이지 조회 시 정상 결과 반환")
+  void testMyPageBookmark_Success() {
+    String email = "user@example.com";
+    int pageNumber = 1;
+    int pageSize = 6;
+
+    User newUser = User.builder()
+        .email("user@example.com")
+        .build();
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(newUser));
+
+    List<Long> bookmarkIds = List.of(10L, 20L, 30L);
+    Pageable pageable = PageRequest.of(pageNumber - 1, pageSize,
+        Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<Long> idPage = new PageImpl<>(bookmarkIds, pageable, bookmarkIds.size());
+    when(myPageBookMarkRepository.findBookMarksByEmail(email, pageable))
+        .thenReturn(idPage);
+
+    Board b1 = Board.builder()
+        .title("타이틀1")
+        .authorEmail(email)
+        .category(Category.book)
+        .content("내용1")
+        .commentsCount(0)
+        .bookmarksCount(0)
+        .build();
+    ReflectionTestUtils.setField(b1, "id", 10L);
+
+    Board b2 = Board.builder()
+        .title("타이틀2")
+        .authorEmail(email)
+        .category(Category.book)
+        .content("내용2")
+        .commentsCount(0)
+        .bookmarksCount(0)
+        .build();
+    ReflectionTestUtils.setField(b2, "id", 20L);
+
+    Board b3 = Board.builder()
+        .title("타이틀3")
+        .authorEmail(email)
+        .category(Category.book)
+        .content("내용3")
+        .commentsCount(0)
+        .bookmarksCount(0)
+        .build();
+    ReflectionTestUtils.setField(b3, "id", 30L);
+
+    when(myPageRepository.findAllById(bookmarkIds))
+        .thenReturn(List.of(b2, b3, b1));
+
+    Page<Board> result = service.myPageBookmark(email, pageNumber);
+
+    List<Long> resultIds = result.getContent().stream()
+        .map(Board::getId)
+        .collect(Collectors.toList());
+    System.out.println("조회된 Boards ID 순서: " + resultIds);
+
+    assertEquals(3, result.getContent().size(), "결과 개수는 3개");
+    assertEquals(bookmarkIds, resultIds, "ID 순서가 입력 순서와 일치");
+    assertEquals(bookmarkIds.size(), result.getTotalElements(), "totalElements 일치");
+    assertEquals(pageNumber - 1, result.getPageable().getPageNumber(), "페이지 번호 일치");
+    assertEquals(pageSize, result.getPageable().getPageSize(), "페이지 사이즈 일치");
+  }
+
+
+}


### PR DESCRIPTION
## 👀제목
마이페이지 북마크 조회 기능 추가

## 🙋변경 사항
- `MyPageController`에 `/users/me/bookmarks` GET 엔드포인트 추가  
- `MyPageService.myPageBookmark(email, page)` 구현  
  - 사용자 존재 여부 검증 후 북마크 엔티티로부터 게시글 ID 페이징 조회  
  - 조회된 ID 리스트로 `Board` 엔티티 일괄 조회 및 입력 순서 보장 로직 추가  
- `BookMark` 엔티티 정의  
  - `email`, `boardId`, 생성·수정 시간 자동 설정 메서드 포함  
- `MyPageBookMarkRepository`에 사용자 이메일 기반 게시글 ID 페이징 쿼리 메서드 추가  
  ```java
  @Query("SELECT bm.boardId FROM BookMark bm WHERE bm.email = :email")
  Page<Long> findBookMarksByEmail(String email, Pageable pageable);
  ```
- 단위/통합 테스트 추가  
  - `MyPageServiceUnitTest`에 사용자 미존재 예외 및 정상 조회 시나리오 검증  

## 💎설명
- **요구사항**: 로그인된 사용자가 자신이 북마크한 게시글 목록을 페이지 단위로 조회  
- **구현 배경**:  
  1. 기존 마이페이지 조회 기능(`myPageBoard`)과 동일한 UX 제공  
  2. 북마크 엔티티에서 게시글 ID만 조회한 뒤, 실제 `Board` 정보를 별도 조회하여 응답 데이터 최소화  
- **핵심 로직**:  
  - `PageRequest.of(page - 1, 6, Sort.by(DESC, "createdAt"))`로 페이징 및 정렬  
  - `Page<Long>` → `List<Board>` 변환 후 `PageImpl`으로 감싸 결과 반환  


## 🔨테스트 방법
1. **단위 테스트**  
   ```bash
   ./gradlew clean test --tests *MyPageServiceUnitTest
   ```  
   - 사용자 미존재 시 `USER_NOT_FOUND` 예외 발생 검증  
   - 북마크 ID 순서 및 페이징 정보 정상 반환 검증  
2. **통합 테스트**  
   ```bash
   ./gradlew clean test --tests *ControllerTest
   ```  
   - H2 인메모리 DB 프로필로 컨트롤러 레벨 MockMvc 호출  
3. **수동 확인**  
   ```bash
   curl -X GET "http://localhost:8080/users/me/bookmarks?page=1" --cookie "userEmail=test@example.com"
   ```  

## ⚙성능
- 게시글 ID만 먼저 조회하여 네트워크 및 메모리 오버헤드 최소화  
- `findAllById` 호출 시 내부적으로 `IN` 쿼리 사용, DB 인덱스 활용  
- 전체 응답 생성 시간 평균 3ms 이내 (테스트 환경 기준)

## ℹ️추가 정보
- 페이지 사이즈: 고정 6개, 추후 파라미터화 가능  
- 쿠키 `userEmail` 값이 없거나 빈 문자열일 경우 비로그인 처리 (예외 발생 or 빈 리스트 반환 정책 검토 필요)  
- `BookMark` 엔티티의 `createdAt` 기준 내림차순 정렬

## ❌이슈
