### PR TITLE
<댓글 추가>feat(댓글추가) : 댓글추가 로직 구현

### DIFF
--- a/src/main/java/com/modureview/controller/CommentController.java
+++ b/src/main/java/com/modureview/controller/CommentController.java
@@ -1,0 +1,29 @@
+package com.modureview.controller;
+
+import com.modureview.dto.request.CommentSaveRequest;
+import com.modureview.service.BoardService;
+import com.modureview.service.CommentService;
+import com.modureview.service.UserService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class CommentController {
+
+  private final UserService userService;
+  private final CommentService commentService;
+
+  @PostMapping("/reviews/{reviewId}/comments")
+  public ResponseEntity<?> addComment(@PathVariable Long reviewId, CommentSaveRequest commentSaveRequest) {
+    Long userId = userService.findUserId(commentSaveRequest.userEmail());
+    commentService.saveComment(reviewId, userId, commentSaveRequest);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+
+}

--- a/src/main/java/com/modureview/dto/request/CommentSaveRequest.java
+++ b/src/main/java/com/modureview/dto/request/CommentSaveRequest.java
@@ -1,0 +1,6 @@
+package com.modureview.dto.request;
+
+import com.modureview.entity.Category;
+
+public record CommentSaveRequest(String userEmail, Category category, String content) {
+}

--- a/src/main/java/com/modureview/entity/Comment.java
+++ b/src/main/java/com/modureview/entity/Comment.java
@@ -1,0 +1,42 @@
+package com.modureview.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long boardId;
+
+  private Long userId;
+
+  private String userEmail;
+
+  private String content;
+
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/modureview/repository/CommentRepository.java
+++ b/src/main/java/com/modureview/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.modureview.repository;
+
+import com.modureview.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment,Long> {
+
+}

--- a/src/main/java/com/modureview/service/CommentService.java
+++ b/src/main/java/com/modureview/service/CommentService.java
@@ -1,0 +1,26 @@
+package com.modureview.service;
+
+import com.modureview.dto.request.CommentSaveRequest;
+import com.modureview.entity.Comment;
+import com.modureview.repository.CommentRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+
+  public void saveComment(Long boardId, Long userId, CommentSaveRequest commentSaveRequest) {
+    Comment comment = Comment.builder()
+        .boardId(boardId)
+        .userEmail(commentSaveRequest.userEmail())
+        .userId(userId)
+        .content(commentSaveRequest.content())
+        .build();
+
+    commentRepository.save(comment);
+
+  }
+}

--- a/src/test/java/com/modureview/controller/CommentControllerTest.java
+++ b/src/test/java/com/modureview/controller/CommentControllerTest.java
@@ -1,0 +1,26 @@
+package com.modureview.controller;
+
+import static com.modureview.entity.Category.food;
+
+import com.modureview.dto.request.CommentSaveRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+class CommentControllerTest {
+
+  @Autowired
+  CommentController commentController;
+
+  @Test
+  @DisplayName("save comment결과")
+  void saveComment() {
+    CommentSaveRequest commentSaveRequest = new CommentSaveRequest("user1@example.com", food,
+        "네네 아이고아이고");
+    commentController.addComment(1L, commentSaveRequest);
+  }
+
+}


### PR DESCRIPTION
## 👀제목
댓글추가

## 💎설명
![image](https://github.com/user-attachments/assets/edaa5a98-af95-4e5d-9541-3f262b2276ad)

1. user이메일을 통해서 user Id찾아오기, CommentSaveRequest를 사용해 requestBody의 값 가져오기
2. comment Entity객체 생성하기
3. CommentService에서 CommentRepository사용해 JPA entity저장하기



## 🔨테스트 방법
Spring 통합 테스트 
실제 애플리케이션을 돌리고 구동시켜 확인 

<img width="767" alt="image" src="https://github.com/user-attachments/assets/360c95e0-42bf-471a-9761-17bd61b69777" />
