### PR TITLE
fix(BoardDetails) : Bookmarks 와 comment_count 삭제로 인한 변경사항입니다.

### DIFF
--- a/src/main/java/com/modureview/dto/response/BoardDetailResponse.java
+++ b/src/main/java/com/modureview/dto/response/BoardDetailResponse.java
@@ -11,10 +11,8 @@ public record BoardDetailResponse(
     Category category,
     String author_email,
     String author_id,
-    LocalDateTime create_At,
-    String content,
-    Integer comment_count,
-    Integer bookmarks
+    LocalDateTime create_at,
+    String content
 ) {
 
 

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -68,10 +68,8 @@ public class BoardService {
         .category(findBoard.getCategory())
         .author_email(findBoard.getAuthorEmail())
         .author_id(findBoard.getAuthorEmail().split("@")[0])
-        .create_At(findBoard.getCreatedAt())
+        .create_at(findBoard.getCreatedAt())
         .content(findBoard.getContent())
-        .comment_count(findBoard.getCommentsCount())
-        .bookmarks(findBoard.getBookmarksCount())
         .build();
   }
 


### PR DESCRIPTION
# 👀제목
Board 상세 응답에서 `comment_count` 및 `bookmarks` 필드 제거

## 🙋변경 사항
- `BoardDetailResponse` DTO에서 `comment_count`, `bookmarks` 필드 삭제  
- `create_At` 필드명 `create_at`로 통일  
- `BoardService.toDetailResponse` 메서드에서 `commentCount`, `bookmarksCount` 매핑 로직 제거  

## 💎설명
- 더 이상 사용되지 않는 댓글 수(`comment_count`)와 북마크 수(`bookmarks`) 응답 필드를 제거하여 API 스펙 단순화  
- 기존 필드 이름의 카멜케이스 오타(`create_At`)를 표준 카멜케이스(`create_at`)로 통일  
- 불필요 로직 삭제로 DTO 변환 과정 경량화  

## 🔨테스트 방법
1. **단위 테스트**  
   ```bash
   ./gradlew clean test --tests *BoardServiceUnitTest
   ```  
   - `toDetailResponse` 호출 시 예외 없이 DTO 생성 검증  
2. **통합 테스트**  
   ```bash
   ./gradlew clean test --tests *BoardControllerTest
   ```  
   - `/boards/{id}` 조회 시 `comment_count` 및 `bookmarks` 필드 미포함 확인  
3. **수동 확인**  
   ```bash
   curl -X GET "http://localhost:8080/boards/1" -H "Accept: application/json"
   ```  
   - JSON 응답에 `comment_count`, `bookmarks` 속성이 존재하지 않는지 확인  

## ⚙성능
- 응답 페이로드 크기 소폭 감소  
- DTO 매핑 로직 경량화로 변환 비용 감소  

## ℹ️추가 정보
- 프론트엔드 상세 페이지 응답 스펙 변경사항 반영 필요  
- 기존 클라이언트 의존 코드(필드 참조 로직) 수정 필요  

## ❌이슈
- 클라이언트 호환성: 제거된 필드를 참조하는 코드 주의 필요  
- 관련 API 버전업 및 문서 갱신 필요
