### PR TITLE
Refactor/slice board response

### DIFF
--- a/src/main/java/com/modureview/controller/MyPageController.java
+++ b/src/main/java/com/modureview/controller/MyPageController.java
@@ -1,12 +1,7 @@
 package com.modureview.controller;
 
-import com.modureview.dto.response.BoardSearchResponse;
-import com.modureview.dto.response.CustomPageResponse;
-import com.modureview.entity.Board;
-import com.modureview.service.MyPageService;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -14,44 +9,52 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.modureview.dto.response.CustomPageResponse;
+import com.modureview.dto.response.SliceBoardResponse;
+import com.modureview.entity.Board;
+import com.modureview.service.MyPageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 public class MyPageController {
 
-  private final MyPageService myPageService;
+	private final MyPageService myPageService;
 
-  @GetMapping("/users/me/reviews")
-  public ResponseEntity<CustomPageResponse<BoardSearchResponse>> getUserBoards(
-      @CookieValue(name = "userEmail") String email,
-      @RequestParam(name = "page", defaultValue = "0") int page
-  ) {
-    Page<Board> boardPage = myPageService.myPageBoard(email, page);
-    List<BoardSearchResponse> listMyPage = boardPage.getContent().stream()
-        .map(BoardSearchResponse::fromEntity)
-        .toList();
-    CustomPageResponse<BoardSearchResponse> myPage = new CustomPageResponse<>(
-        listMyPage,
-        boardPage.getNumber() + 1,
-        boardPage.getTotalPages()
-    );
-    return ResponseEntity.ok(myPage);
-  }
+	@GetMapping("/users/me/reviews")
+	public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getUserBoards(
+		@CookieValue(name = "userEmail") String email,
+		@RequestParam(name = "page", defaultValue = "0") int page
+	) {
+		Page<Board> boardPage = myPageService.myPageBoard(email, page);
+		List<SliceBoardResponse> listMyPage = boardPage.getContent().stream()
+			.map(SliceBoardResponse::fromEntity)
+			.toList();
+		CustomPageResponse<SliceBoardResponse> myPage = new CustomPageResponse<>(
+			listMyPage,
+			boardPage.getNumber() + 1,
+			boardPage.getTotalPages()
+		);
+		return ResponseEntity.ok(myPage);
+	}
 
-  @GetMapping("/users/me/bookmarks")
-  public ResponseEntity<CustomPageResponse<BoardSearchResponse>> getBookMarkBoards(
-      @CookieValue(name = "userEmail") String email,
-      @RequestParam(name = "page", defaultValue = "0") int page
-  ) {
-    Page<Board> boardMyPage = myPageService.myPageBookmark(email, page);
-    List<BoardSearchResponse> listMyPage = boardMyPage.getContent().stream()
-        .map(BoardSearchResponse::fromEntity)
-        .toList();
-    CustomPageResponse<BoardSearchResponse> myPage = new CustomPageResponse<>(
-        listMyPage,
-        boardMyPage.getNumber() + 1,
-        boardMyPage.getTotalPages()
-    );
-    return ResponseEntity.ok(myPage);
-  }
+	@GetMapping("/users/me/bookmarks")
+	public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getBookMarkBoards(
+		@CookieValue(name = "userEmail") String email,
+		@RequestParam(name = "page", defaultValue = "0") int page
+	) {
+		Page<Board> boardMyPage = myPageService.myPageBookmark(email, page);
+		List<SliceBoardResponse> listMyPage = boardMyPage.getContent().stream()
+			.map(SliceBoardResponse::fromEntity)
+			.toList();
+		CustomPageResponse<SliceBoardResponse> myPage = new CustomPageResponse<>(
+			listMyPage,
+			boardMyPage.getNumber() + 1,
+			boardMyPage.getTotalPages()
+		);
+		return ResponseEntity.ok(myPage);
+	}
 }

--- a/src/main/java/com/modureview/controller/SearchController.java
+++ b/src/main/java/com/modureview/controller/SearchController.java
@@ -1,17 +1,10 @@
 package com.modureview.controller;
 
-import com.modureview.dto.response.BoardSearchResponse;
-import com.modureview.dto.response.CustomPageResponse;
-import com.modureview.dto.response.CustomSlicePageResponse;
-import com.modureview.entity.Board;
-import com.modureview.entity.Category;
-import com.modureview.service.SearchService;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
@@ -19,63 +12,70 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.modureview.dto.response.CustomPageResponse;
+import com.modureview.dto.response.CustomSlicePageResponse;
+import com.modureview.dto.response.SliceBoardResponse;
+import com.modureview.entity.Board;
+import com.modureview.entity.Category;
+import com.modureview.service.SearchService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 public class SearchController {
 
-  private final SearchService searchService;
+	private final SearchService searchService;
 
+	@GetMapping("/search")
+	public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getBoardSearch(
+		@RequestParam(name = "keyword") String keyword,
+		@RequestParam(name = "page", defaultValue = "0") int page,
+		@RequestParam(name = "sort", defaultValue = "recent") String sort
+	) throws UnsupportedEncodingException {
+		String decodeKeyword = URLDecoder.decode(keyword, "UTF-8");
+		log.info("Searching for " + decodeKeyword);
+		Page<Board> boardPage = searchService.boardSearch(decodeKeyword, page, sort);
+		List<SliceBoardResponse> listSearchBoard = boardPage.getContent().stream()
+			.map(SliceBoardResponse::fromEntity)
+			.toList();
+		CustomPageResponse<SliceBoardResponse> SearchPage = new CustomPageResponse<>(
+			listSearchBoard,
+			boardPage.getNumber() + 1,
+			boardPage.getTotalPages()
+		);
 
-  @GetMapping("/search")
-  public ResponseEntity<CustomPageResponse<BoardSearchResponse>> getBoardSearch(
-      @RequestParam(name = "keyword") String keyword,
-      @RequestParam(name = "page", defaultValue = "0") int page,
-      @RequestParam(name = "sort", defaultValue = "recent") String sort
-  ) throws UnsupportedEncodingException {
-    String decodeKeyword = URLDecoder.decode(keyword, "UTF-8");
-    log.info("Searching for " + decodeKeyword);
-    Page<Board> boardPage = searchService.boardSearch(decodeKeyword, page, sort);
-    List<BoardSearchResponse> listSearchBoard = boardPage.getContent().stream()
-        .map(BoardSearchResponse::fromEntity)
-        .toList();
-    CustomPageResponse<BoardSearchResponse> SearchPage = new CustomPageResponse<>(
-        listSearchBoard,
-        boardPage.getNumber() + 1,
-        boardPage.getTotalPages()
-    );
+		return ResponseEntity.ok().body(SearchPage);
+	}
 
-    return ResponseEntity.ok().body(SearchPage);
-  }
+	@GetMapping("/reviews")
+	public ResponseEntity<CustomSlicePageResponse<SliceBoardResponse>> getBoardsByCategory(
+		@RequestParam(name = "categoryId") Category category,
+		@RequestParam(name = "cursor", defaultValue = "0") Long cursorId,
+		@RequestParam(name = "sort", defaultValue = "recent") String sort) {
+		Slice<Board> boardSlice = searchService.getCategoryBoard(category, cursorId, sort);
+		List<SliceBoardResponse> dtoList = boardSlice.getContent().stream()
+			.map(SliceBoardResponse::fromEntity)
+			.collect(Collectors.toList());
 
+		Long nextCursorValue = null;
+		if (boardSlice.hasNext() && !boardSlice.getContent().isEmpty()) {
+			Board lastBoardInSlice = boardSlice.getContent().get(boardSlice.getContent().size() - 1);
+			nextCursorValue = lastBoardInSlice.getId();
+		}
 
-  @GetMapping("/reviews")
-  public ResponseEntity<CustomSlicePageResponse<BoardSearchResponse>> getBoardsByCategory(
-      @RequestParam(name = "categoryId") Category category,
-      @RequestParam(name = "cursor", defaultValue = "0") Long cursorId,
-      @RequestParam(name = "sort", defaultValue = "recent") String sort) {
-    Slice<Board> boardSlice = searchService.getCategoryBoard(category, cursorId, sort);
-    List<BoardSearchResponse> dtoList = boardSlice.getContent().stream()
-        .map(BoardSearchResponse::fromEntity)
-        .collect(Collectors.toList());
+		CustomSlicePageResponse<SliceBoardResponse> customResponse = new CustomSlicePageResponse<>(
+			dtoList,
+			nextCursorValue,
+			boardSlice.hasNext(),
+			boardSlice.getNumberOfElements(),
+			boardSlice.getSize(),
+			boardSlice.isFirst()
+		);
 
-    Long nextCursorValue = null;
-    if (boardSlice.hasNext() && !boardSlice.getContent().isEmpty()) {
-      Board lastBoardInSlice = boardSlice.getContent().get(boardSlice.getContent().size() - 1);
-      nextCursorValue = lastBoardInSlice.getId();
-    }
-
-    CustomSlicePageResponse<BoardSearchResponse> customResponse = new CustomSlicePageResponse<>(
-        dtoList,
-        nextCursorValue,
-        boardSlice.hasNext(),
-        boardSlice.getNumberOfElements(),
-        boardSlice.getSize(),
-        boardSlice.isFirst()
-    );
-
-    return ResponseEntity.ok(customResponse);
-  }
-
+		return ResponseEntity.ok(customResponse);
+	}
 
 }

--- a/src/main/java/com/modureview/dto/response/SliceBoardResponse.java
+++ b/src/main/java/com/modureview/dto/response/SliceBoardResponse.java
@@ -4,10 +4,9 @@ import com.modureview.entity.Board;
 import com.modureview.entity.Category;
 import java.time.LocalDateTime;
 import lombok.Builder;
-import org.springframework.beans.factory.annotation.Value;
 
 @Builder
-public record BoardSearchResponse(
+public record SliceBoardResponse(
     Long board_id,
     String title,
     String author_id,
@@ -22,9 +21,9 @@ public record BoardSearchResponse(
 
 
 
-  public static BoardSearchResponse fromEntity(Board board) {
+  public static SliceBoardResponse fromEntity(Board board) {
 
-    return BoardSearchResponse.builder()
+    return SliceBoardResponse.builder()
         .board_id(board.getId())
         .title(board.getTitle())
         .category(board.getCategory())

--- a/src/main/java/com/modureview/service/SearchService.java
+++ b/src/main/java/com/modureview/service/SearchService.java
@@ -1,15 +1,5 @@
 package com.modureview.service;
 
-
-import com.modureview.entity.Board;
-import com.modureview.entity.Category;
-import com.modureview.enums.errors.BoardErrorCode;
-import com.modureview.exception.CustomException;
-import com.modureview.repository.BoardRepository;
-import com.modureview.repository.SearchRepository;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,102 +9,114 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import com.modureview.entity.Board;
+import com.modureview.entity.Category;
+import com.modureview.enums.errors.BoardErrorCode;
+import com.modureview.exception.CustomException;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.SearchRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class SearchService {
 
-  private final SearchRepository searchRepository;
-  private final BoardRepository boardRepository;
+	private final SearchRepository searchRepository;
+	private final BoardRepository boardRepository;
 
-  public Page<Board> boardSearch(String keyword, int page, String sort) {
-    Sort sortCriteria;
+	public Page<Board> boardSearch(String keyword, int page, String sort) {
+		Sort sortCriteria;
 
-    switch (sort.toLowerCase()) {
-      case "hotbookmarks" -> sortCriteria = Sort.by(Direction.DESC, "bookmarksCount");
-      case "hotcomments" -> sortCriteria = Sort.by(Direction.DESC, "commentsCount");
-      case "recent" -> sortCriteria = Sort.by(Direction.DESC, "createdAt");
-      default -> sortCriteria = Sort.by(Direction.DESC, "createdAt");
-    }
+		switch (sort.toLowerCase()) {
+			case "hotbookmarks" -> sortCriteria = Sort.by(Direction.DESC, "bookmarksCount");
+			case "hotcomments" -> sortCriteria = Sort.by(Direction.DESC, "commentsCount");
+			case "recent" -> sortCriteria = Sort.by(Direction.DESC, "createdAt");
+			default -> sortCriteria = Sort.by(Direction.DESC, "createdAt");
+		}
 
-    Pageable pageable = PageRequest.of(page - 1, 6, sortCriteria);
-    if (StringUtils.hasText(keyword)) {
-      return searchRepository.findByKeyword(keyword, pageable);
-    } else {
-      throw new CustomException(BoardErrorCode.BOARD_SEARCH_KEYWORD_NOTFOUND);
-    }
-  }
+		Pageable pageable = PageRequest.of(page - 1, 6, sortCriteria);
+		if (StringUtils.hasText(keyword)) {
+			return searchRepository.findByKeyword(keyword, pageable);
+		} else {
+			throw new CustomException(BoardErrorCode.BOARD_SEARCH_KEYWORD_NOTFOUND);
+		}
+	}
 
-  public Slice<Board> getCategoryBoard(Category category, Long cursor, String sort) {
-    Pageable pageable = PageRequest.of(0, 6);
-    log.info("category == {}", category);
-    log.info("sort == {}", sort);
-    switch (sort) {
-      case "recent":
-        if (cursor == 0) {
-          if (category == Category.all) {
-            return searchRepository.findAllOrderByCreatedAtFirst(pageable);
-          } else {
-            return searchRepository.findByCategoryOrderByCreatedAtFirst(category, pageable);
-          }
-        } else {
-          Board board = foundBoard(cursor);
-          if (category == Category.all) {
-            return searchRepository.findAllOrderByCreatedAt(board.getCreatedAt(),
-                board.getId(), pageable);
-          } else {
-            return searchRepository.findByCategoryOrderByCreatedAt(category,
-                board.getCreatedAt(), board.getId(), pageable);
-          }
+	public Slice<Board> getCategoryBoard(Category category, Long cursor, String sort) {
+		Pageable pageable = PageRequest.of(0, 6);
+		log.info("category == {}", category);
+		log.info("sort == {}", sort);
+		switch (sort) {
+			case "recent":
+				if (cursor == 0) {
+					if (category == Category.all) {
+						return searchRepository.findAllOrderByCreatedAtFirst(pageable);
+					} else {
+						return searchRepository.findByCategoryOrderByCreatedAtFirst(category, pageable);
+					}
+				} else {
+					Board board = foundBoard(cursor);
+					if (category == Category.all) {
+						return searchRepository.findAllOrderByCreatedAt(board.getCreatedAt(),
+							board.getId(), pageable);
+					} else {
+						return searchRepository.findByCategoryOrderByCreatedAt(category,
+							board.getCreatedAt(), board.getId(), pageable);
+					}
 
-        }
-      case "hotbookmarks":
-        if (cursor == 0) {
-          if (category == Category.all) {
-            return searchRepository.findAllOrderByBookmarksCountFirst(pageable);
-          } else {
-            return searchRepository.findByCategoryOrderByBookmarksCountFirst(category,
-                pageable);
-          }
-        } else {
-          Board board = foundBoard(cursor);
-          if (category == Category.all) {
-            return searchRepository.findAllOrderByBookmarksCount(board.getBookmarksCount(),
-                board.getId(), pageable);
-          } else {
-            return searchRepository.findByCategoryOrderByBookmarksCount(category,
-                board.getBookmarksCount(), board.getId(), pageable);
-          }
-        }
-      case "hotcomments":
-        if (cursor == 0) {
-          if (category == Category.all) {
-            return searchRepository.findAllOrderByCommentsCountFirst(pageable);
-          } else {
-            return searchRepository.findByCategoryOrderByCommentsCountFirst(category,
-                pageable);
-          }
+				}
+			case "hotbookmarks":
+				if (cursor == 0) {
+					if (category == Category.all) {
+						return searchRepository.findAllOrderByBookmarksCountFirst(pageable);
+					} else {
+						return searchRepository.findByCategoryOrderByBookmarksCountFirst(category,
+							pageable);
+					}
+				} else {
+					Board board = foundBoard(cursor);
+					if (category == Category.all) {
+						return searchRepository.findAllOrderByBookmarksCount(board.getBookmarksCount(),
+							board.getId(), pageable);
+					} else {
+						return searchRepository.findByCategoryOrderByBookmarksCount(category,
+							board.getBookmarksCount(), board.getId(), pageable);
+					}
+				}
+			case "hotcomments":
+				if (cursor == 0) {
 
-        } else {
-          Board board = foundBoard(cursor);
-          if (category == Category.all) {
-            searchRepository.findAllOrderByCommentsCount(board.getCommentsCount(),
-                board.getId(), pageable);
-          } else {
-            return searchRepository.findByCategoryOrderByCommentsCount(category,
-                board.getCommentsCount(), board.getId(), pageable);
-          }
+					if (category == Category.all) {
+						return searchRepository.findAllOrderByCommentsCountFirst(pageable);
+					} else {
+						return searchRepository.findByCategoryOrderByCommentsCountFirst(category,
+							pageable);
+					}
 
-        }
-      default:
-        return searchRepository.findByCategoryOrderByCreatedAtFirst(category, pageable);
-    }
+				} else {
+					Board board = foundBoard(cursor);
+					if (category == Category.all) {
+						searchRepository.findAllOrderByCommentsCount(board.getCommentsCount(),
+							board.getId(), pageable);
+					} else {
+						return searchRepository.findByCategoryOrderByCommentsCount(category,
+							board.getCommentsCount(), board.getId(), pageable);
+					}
 
-  }
+				}
+			default:
+				return searchRepository.findByCategoryOrderByCreatedAtFirst(category, pageable);
+		}
 
-  public Board foundBoard(Long id) {
-    return boardRepository.findById(id)
-        .orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
-  }
+	}
+
+	public Board foundBoard(Long id) {
+		return boardRepository.findById(id)
+			.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
+	}
 }


### PR DESCRIPTION
👀제목

SliceBoardResponse로 리팩토링하여 검색 및 마이페이지 응답 구조 개선

🙋변경 사항
	•	BoardSearchResponse → SliceBoardResponse로 DTO 클래스 리네이밍 및 구조 개선
	•	MyPageController, SearchController에서 관련 응답 DTO를 SliceBoardResponse로 변경
	•	SearchService 내부 로직 일부 정리 및 리팩토링
	•	페이징 응답 타입 CustomPageResponse, CustomSlicePageResponse를 일관성 있게 적용

💎설명

기존에 BoardSearchResponse를 통해 게시글 정보를 반환하던 로직에서, 의미상 더 적절하고 일관성 있는 SliceBoardResponse로 변경하였습니다. 이로 인해 MyPageController 및 SearchController의 응답 구조가 변경되며, 코드의 가독성과 유지보수성이 개선됩니다. 또한, SearchService 내에서 정렬 조건 및 커서 기반 페이징 처리 로직을 개선하여 가독성을 높였습니다.

🔨테스트 방법
	•	API /users/me/reviews, /users/me/bookmarks 요청 시 변경된 응답 DTO 구조(SliceBoardResponse)로 정상 응답 확인
	•	/search, /reviews 검색 및 카테고리별 조회 요청 시 정상 동작 여부 및 응답 데이터의 구조 확인
	•	기존 기능의 정상 동작 여부와 변경된 응답 필드 확인 (수동 테스트 수행)

⚙성능
	•	성능 영향은 없음
	•	DTO 명 변경 및 정렬 로직 리팩토링으로 유지보수성과 응답 일관성 향상

ℹ️추가 정보
	•	기존 BoardSearchResponse는 더 이상 사용되지 않으므로 추후 제거 가능
	•	SliceBoardResponse로 통합하여 응답의 일관성을 유지할 수 있음

❌이슈
	•	해당 PR과 직접 연결된 이슈는 없음