### PR TITLE
Refact/error code Front 와 설정한 에러코드 형식으로 템플릿 변경

### DIFF
--- a/src/main/java/com/modureview/enums/ErrorCode.java
+++ b/src/main/java/com/modureview/enums/ErrorCode.java
@@ -3,8 +3,9 @@ package com.modureview.enums;
 import org.springframework.http.HttpStatus;
 
 public interface ErrorCode {
+  String getTitle();
   HttpStatus getHttpStatus();
-  String getMessage();
+  String getDetail();
 
 
 }

--- a/src/main/java/com/modureview/enums/errors/BestReviewErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/BestReviewErrorCode.java
@@ -4,24 +4,31 @@ import com.modureview.enums.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum BestReviewErrorCode implements ErrorCode {
-  JSON_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "JSON파싱중 에러가 발생했습니다."),
-  MYSQL_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Mysql Server에 연겷할 수 없습니다."),
-  REDIS_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis Server에 연결할 수 없습니다.");
+  JSON_PROCESSING_ERROR("JSON_PARSING_ERROR",HttpStatus.INTERNAL_SERVER_ERROR, "JSON파싱중 에러가 발생했습니다.");
 
+  private final String title;
   private final HttpStatus httpStatus;
-  private final String message;
+  private final String detail;
 
-  BestReviewErrorCode(HttpStatus httpStatus, String message) {
+  BestReviewErrorCode(String title ,HttpStatus httpStatus, String detail) {
+    this.title = title;
     this.httpStatus = httpStatus;
-    this.message = message;
+    this.detail = detail;
+  }
+
+  @Override
+  public String getTitle() {
+    return "";
   }
 
   @Override
   public HttpStatus getHttpStatus() {
     return httpStatus;
   }
+
   @Override
-  public String getMessage() {
-    return message;
+  public String getDetail() {
+    return "";
   }
+
 }

--- a/src/main/java/com/modureview/enums/errors/BoardErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/BoardErrorCode.java
@@ -4,28 +4,38 @@ import com.modureview.enums.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum BoardErrorCode implements ErrorCode {
-  BOARD_ID_NOTFOUND(HttpStatus.NOT_FOUND,"게시글을 찾을 수 없습니다."),
-  NOT_ALLOWED_HTML_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"잘못된 html입니다."),
-  BOARD_SAVE_ERROR(HttpStatus.CONFLICT,"데이터를 저장할 수 없습니다."),
-  IMG_SRC_EXTRACT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"html에서 이미지 추출중 에러가 발생했습니다."),
-  BOARD_SEARCH_KEYWORD_NOTFOUND( HttpStatus.NOT_FOUND, "키워드를 찾을 수 없습니다." ),
-  BOARD_NOT_EXIST(HttpStatus.INTERNAL_SERVER_ERROR, "게시글이 존재하지 않습니다."),
-  INVALID_BOARD_ID_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 파라미터 형식입니다.");
+  BOARD_ID_NOTFOUND("BOARD_ID_NOT_FOUND", HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+  NOT_ALLOWED_HTML_ERROR("WRONG_HTML_TYPE", HttpStatus.INTERNAL_SERVER_ERROR, "잘못된 html입니다."),
+  BOARD_SAVE_ERROR("CAN_NOT_SAVE_DATA", HttpStatus.CONFLICT, "데이터를 저장할 수 없습니다."),
+  IMG_SRC_EXTRACT_ERROR("EXTRACT_IMAGE_ERROR", HttpStatus.INTERNAL_SERVER_ERROR,
+      "html에서 이미지 추출중 에러가 발생했습니다."),
+  BOARD_SEARCH_KEYWORD_NOTFOUND("KEYWORD_NOT_FOUND", HttpStatus.NOT_FOUND, "키워드를 찾을 수 없습니다."),
+  BOARD_NOT_EXIST("BOARD_NOT_EXIST", HttpStatus.INTERNAL_SERVER_ERROR, "게시글이 존재하지 않습니다."),
+  INVALID_BOARD_ID_FORMAT("INVALID_BOARD_ID_FORMAT", HttpStatus.BAD_REQUEST, "잘못된 파라미터 형식입니다.");
 
+  private final String title;
   private final HttpStatus httpStatus;
-  private final String message;
+  private final String detail;
 
-  BoardErrorCode(HttpStatus httpStatus, String message) {
+  BoardErrorCode(String title, HttpStatus httpStatus, String detail
+  ) {
     this.httpStatus = httpStatus;
-    this.message = message;
+    this.title = title;
+    this.detail = detail;
+  }
+
+  @Override
+  public String getTitle() {
+    return title;
   }
 
   @Override
   public HttpStatus getHttpStatus() {
     return httpStatus;
   }
+
   @Override
-  public String getMessage() {
-    return message;
+  public String getDetail() {
+    return detail;
   }
 }

--- a/src/main/java/com/modureview/enums/errors/BookmarkErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/BookmarkErrorCode.java
@@ -4,15 +4,22 @@ import com.modureview.enums.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum BookmarkErrorCode implements ErrorCode {
-  BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "북마크를 찾을 수 없습니다."),
+  BOOKMARK_NOT_FOUND("BOOKMARK_NOT_FOUND",HttpStatus.NOT_FOUND, "북마크를 찾을 수 없습니다."),
   ;
 
+  private final String title;
   private final HttpStatus httpStatus;
-  private final String message;
+  private final String detail;
 
-  BookmarkErrorCode(HttpStatus httpStatus, String message) {
+  BookmarkErrorCode(String title, HttpStatus httpStatus, String detail) {
+    this.title = title;
     this.httpStatus = httpStatus;
-    this.message = message;
+    this.detail = detail;
+  }
+
+  @Override
+  public String getTitle() {
+    return "";
   }
 
   @Override
@@ -21,7 +28,8 @@ public enum BookmarkErrorCode implements ErrorCode {
   }
 
   @Override
-  public String getMessage() {
+  public String getDetail() {
     return "";
   }
+
 }

--- a/src/main/java/com/modureview/enums/errors/ImageSaveErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/ImageSaveErrorCode.java
@@ -4,18 +4,25 @@ import com.modureview.enums.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum ImageSaveErrorCode implements ErrorCode {
-  CAN_NOT_CREATE_PRESIGNED_URL(HttpStatus.INTERNAL_SERVER_ERROR,
+  CAN_NOT_CREATE_PRESIGNED_URL("CAN_NOT_CREATE_PRESIGNED_URL",HttpStatus.INTERNAL_SERVER_ERROR,
       "S3 PresignedURL을 생성할 수 없습니다."),
 
-  CAN_NOT_CREATE_UUID(HttpStatus.INTERNAL_SERVER_ERROR,
+  CAN_NOT_CREATE_UUID("CAT_NOT_CREATE_UUID",HttpStatus.INTERNAL_SERVER_ERROR,
       "이미지 uuid를 생성할 수 없습니다.");
 
+  private final String title;
   private final HttpStatus httpStatus;
-  private final String message;
+  private final String detail;
 
-  ImageSaveErrorCode(HttpStatus httpStatus, String message) {
+  ImageSaveErrorCode(String title ,HttpStatus httpStatus, String detail) {
+    this.title = title;
     this.httpStatus = httpStatus;
-    this.message = message;
+    this.detail = detail;
+  }
+
+  @Override
+  public String getTitle() {
+    return "";
   }
 
   @Override
@@ -24,7 +31,9 @@ public enum ImageSaveErrorCode implements ErrorCode {
   }
 
   @Override
-  public String getMessage() {
-    return message;
+  public String getDetail() {
+    return "";
   }
+
+
 }

--- a/src/main/java/com/modureview/enums/errors/JwtErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/JwtErrorCode.java
@@ -5,24 +5,33 @@ import org.springframework.http.HttpStatus;
 
 public enum JwtErrorCode implements ErrorCode {
 
-  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
-  FORBIDDEN(HttpStatus.FORBIDDEN, "유효하지 않은 사용자입니다.");
+  UNAUTHORIZED("UNAUTHORIZED", HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+  FORBIDDEN("FORBIDDEN", HttpStatus.FORBIDDEN, "유효하지 않은 사용자입니다.");
 
+  private final String title;
   private final HttpStatus httpStatus;
-  private final String message;
+  private final String detail;
 
-  JwtErrorCode(HttpStatus httpStatus, String message) {
+  JwtErrorCode(String title, HttpStatus httpStatus, String detail) {
+    this.title = title;
     this.httpStatus = httpStatus;
-    this.message = message;
+    this.detail = detail;
   }
 
-  @Override // 인터페이스 메서드 구현 명시
+
+  @Override
+  public String getTitle() {
+    return title;
+  }
+
+  @Override
   public HttpStatus getHttpStatus() {
     return httpStatus;
   }
 
-  @Override // 인터페이스 메서드 구현 명시
-  public String getMessage() {
-    return message;
+  @Override
+  public String getDetail() {
+    return detail;
   }
+
 }

--- a/src/main/java/com/modureview/enums/errors/UserErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/UserErrorCode.java
@@ -4,14 +4,23 @@ import com.modureview.enums.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum UserErrorCode implements ErrorCode {
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않은 사용자입니다.");
+  USER_NOT_FOUND("USER_NOT_FOUND",HttpStatus.NOT_FOUND, "존재하지 않은 사용자입니다.");
 
+  private final String title;
   private final HttpStatus httpStatus;
-  private final String message;
+  private final String detail;
 
-  UserErrorCode(HttpStatus httpStatus, String message) {
+
+  UserErrorCode(String title, HttpStatus httpStatus, String detail) {
+    this.title = title;
     this.httpStatus = httpStatus;
-    this.message = message;
+    this.detail = detail;
+  }
+
+
+  @Override
+  public String getTitle() {
+    return title;
   }
 
   @Override
@@ -20,7 +29,7 @@ public enum UserErrorCode implements ErrorCode {
   }
 
   @Override
-  public String getMessage() {
-    return message;
+  public String getDetail() {
+    return detail;
   }
 }

--- a/src/main/java/com/modureview/exception/CustomException.java
+++ b/src/main/java/com/modureview/exception/CustomException.java
@@ -7,16 +7,19 @@ public class CustomException extends RuntimeException {
 
 
   public CustomException(ErrorCode errorCode) {
-    super(errorCode.getMessage()); // 부모 생성자에 메시지 전달
+    super(errorCode.getDetail());
     this.errorCode = errorCode;
   }
 
+  public String title() {
+    return errorCode.getTitle();
+  }
   public ErrorCode getErrorCode() {
     return this.errorCode;
   }
 
 
   public String getErrorMessage() {
-    return errorCode.getMessage();
+    return errorCode.getDetail();
   }
 }

--- a/src/main/java/com/modureview/service/BestReviewsService.java
+++ b/src/main/java/com/modureview/service/BestReviewsService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.modureview.dto.response.BestReviewResponse;
 import com.modureview.entity.Board;
 import com.modureview.entity.Category;
+import com.modureview.enums.errors.BestReviewErrorCode;
+import com.modureview.exception.bestReviewException.JsonParsingException;
 import com.modureview.repository.BoardRepository;
 import java.time.Duration;
 import java.util.Arrays;
@@ -49,7 +51,7 @@ public class BestReviewsService {
             return objectMapper.readValue(json, BestReviewResponse.class);
           } catch (JsonProcessingException e) {
             log.error("Redis의 JSON을 DTO로 변환하는 데 실패했습니다.", e);
-            return null;
+            throw new JsonParsingException(BestReviewErrorCode.JSON_PROCESSING_ERROR);
           }
 
         })


### PR DESCRIPTION
## 👀제목
Front와 설정한 에러코드 형식으로 에러코드 변환

## 🙋변경 사항
ErrorCode에서 title, httpStatus, detail 세 가지 항목을 리턴하도록 변경함

## 💎설명
ErrorCode enum에 title을 추가했다. 
messges-> detail로 에러 코드 설명의 이름을 변경했다.

## ℹ️추가 정보
현재 정해진 title이 front와 협업한 이름과 다르다, 추후에 로직을 보면서 변경이 필요하다. 
추가적으로 Front와 title을 정하는 과정이 필요하다.
