### PR TITLE
 Feat/user reviews

### DIFF
--- a/src/main/java/com/modureview/controller/UserReviewsController.java
+++ b/src/main/java/com/modureview/controller/UserReviewsController.java
@@ -1,0 +1,55 @@
+package com.modureview.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.modureview.dto.response.CustomSlicePageResponse;
+import com.modureview.dto.response.SliceBoardResponse;
+import com.modureview.entity.Board;
+import com.modureview.service.UserReviewsService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class UserReviewsController {
+	private final UserReviewsService userReviewsService;
+
+	@GetMapping("/users/{memberEmail}")
+	public ResponseEntity<CustomSlicePageResponse<SliceBoardResponse>> getBoardsByUserEmail(
+		@PathVariable String memberEmail,
+		@RequestParam(name = "cursor", defaultValue = "0") Long cursor,
+		@RequestParam(name = "sort", defaultValue = "recent") String sort
+	) {
+		Slice<Board> boardSlice = userReviewsService.UserReviews(memberEmail, cursor, sort);
+		List<SliceBoardResponse> dtoList = boardSlice.getContent().stream()
+			.map(SliceBoardResponse::fromEntity)
+			.collect(Collectors.toList());
+
+		Long nextCursorValue = null;
+		if (boardSlice.hasNext() && !boardSlice.getContent().isEmpty()) {
+			Board lastBoardInSlice = boardSlice.getContent().get(boardSlice.getContent().size() - 1);
+			nextCursorValue = lastBoardInSlice.getId();
+		}
+
+		CustomSlicePageResponse<SliceBoardResponse> customResponse = new CustomSlicePageResponse<>(
+			dtoList,
+			nextCursorValue,
+			boardSlice.hasNext(),
+			boardSlice.getNumberOfElements(),
+			boardSlice.getSize(),
+			boardSlice.isFirst()
+		);
+
+		return ResponseEntity.ok(customResponse);
+	}
+}

--- a/src/main/java/com/modureview/controller/UserReviewsController.java
+++ b/src/main/java/com/modureview/controller/UserReviewsController.java
@@ -30,7 +30,7 @@ public class UserReviewsController {
 		@RequestParam(name = "cursor", defaultValue = "0") Long cursor,
 		@RequestParam(name = "sort", defaultValue = "recent") String sort
 	) {
-		Slice<Board> boardSlice = userReviewsService.UserReviews(memberEmail, cursor, sort);
+		Slice<Board> boardSlice = userReviewsService.userReviews(memberEmail, cursor, sort);
 		List<SliceBoardResponse> dtoList = boardSlice.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.collect(Collectors.toList());

--- a/src/main/java/com/modureview/repository/UserReviewsRepository.java
+++ b/src/main/java/com/modureview/repository/UserReviewsRepository.java
@@ -1,0 +1,55 @@
+package com.modureview.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.modureview.entity.Board;
+
+@Repository
+public interface UserReviewsRepository extends JpaRepository<Board, Long> {
+	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
+		+ "AND (b.createdAt < :createdAt OR "
+		+ " (b.createdAt = :createdAt AND b.id < :boardId)) "
+		+ "ORDER BY b.createdAt DESC , b.id DESC")
+	Slice<Board> findByAuthorEmailByCreatedAt(
+		@Param("authorEmail") String authorEmail,
+		@Param("createdAt") LocalDateTime createdAt,
+		@Param("boardId") Long boardId,
+		Pageable pageable
+	);
+
+	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
+		+ "AND(b.bookmarksCount < :bookmarksCount OR "
+		+ "(b.bookmarksCount = :bookmarksCount AND b.id < :boardId)) "
+		+ "ORDER BY b.bookmarksCount DESC , b.id DESC")
+	Slice<Board> findByAuthorEmailByBookmarksCount(
+		@Param("authorEmail") String authorEmail,
+		@Param("bookmarksCount") Integer bookmarksCount,
+		@Param("boardId") Long boardId,
+		Pageable pageable
+	);
+
+	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
+		+ "AND(b.commentsCount < :commentsCount OR "
+		+ "(b.commentsCount = :commentsCount AND b.id < :boardId)) "
+		+ "ORDER BY b.commentsCount DESC , b.id DESC")
+	Slice<Board> findByAuthorEmailByCommentsCount(
+		@Param("authorEmail") String authorEmail,
+		@Param("commentsCount") Integer commentsCount,
+		@Param("boardId") Long boardId,
+		Pageable pageable
+	);
+
+	Board findTopByAuthorEmailOrderByCreatedAtDesc(String authorEmail);
+
+	Board findTopByAuthorEmailOrderByBookmarksCountDesc(String authorEmail);
+
+	Board findTopByAuthorEmailOrderByCommentsCountDesc(String authorEmail);
+
+}

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -1,0 +1,78 @@
+package com.modureview.service;
+
+import java.util.ArrayList;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.modureview.entity.Board;
+import com.modureview.enums.errors.BoardErrorCode;
+import com.modureview.exception.CustomException;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.UserReviewsRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class UserReviewsService {
+	private final UserReviewsRepository userReviewsRepository;
+	private final BoardRepository boardRepository;
+
+	public Slice<Board> UserReviews(String nickname, Long cursorId, String sort) {
+		Pageable pageable = PageRequest.of(0, 6);
+		log.info("nickname == {}", nickname);
+		log.info("cursorId == {}", cursorId);
+		log.info("sort == {}", sort);
+
+		Board targetBoard;
+
+		if (cursorId == null || cursorId == 0L) {
+			// 초기 로딩: 해당 사용자의 최신/최다 게시글 찾기
+			switch (sort) {
+				case "recent":
+					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
+					break;
+				case "hotbookmarks":
+					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByBookmarksCountDesc(nickname);
+					break;
+				case "hotcomments":
+					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCommentsCountDesc(nickname);
+					break;
+				default:
+					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
+			}
+			
+			// 사용자의 게시글이 없는 경우 빈 Slice 반환
+			if (targetBoard == null) {
+				return new SliceImpl<>(new ArrayList<>(), pageable, false);
+			}
+			
+		} else {
+			targetBoard = boardRepository.findById(cursorId)
+				.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
+		}
+		switch (sort) {
+			case "recent":
+				return userReviewsRepository.findByAuthorEmailByCreatedAt(nickname, targetBoard.getCreatedAt(),
+					targetBoard.getId(), pageable);
+			case "hotbookmarks":
+				return userReviewsRepository.findByAuthorEmailByBookmarksCount(nickname,
+					targetBoard.getBookmarksCount(), targetBoard.getId(), pageable);
+			case "hotcomments":
+				return userReviewsRepository.findByAuthorEmailByCommentsCount(nickname,
+					targetBoard.getCommentsCount(), targetBoard.getId(), pageable);
+
+		}
+		return userReviewsRepository.findByAuthorEmailByCreatedAt(nickname, targetBoard.getCreatedAt(),
+			targetBoard.getId(), pageable);
+	}
+
+}

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -26,7 +26,7 @@ public class UserReviewsService {
 	private final UserReviewsRepository userReviewsRepository;
 	private final BoardRepository boardRepository;
 
-	public Slice<Board> UserReviews(String nickname, Long cursorId, String sort) {
+	public Slice<Board> userReivews(String nickname, Long cursorId, String sort) {
 		Pageable pageable = PageRequest.of(0, 6);
 		log.info("nickname == {}", nickname);
 		log.info("cursorId == {}", cursorId);

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -26,7 +26,7 @@ public class UserReviewsService {
 	private final UserReviewsRepository userReviewsRepository;
 	private final BoardRepository boardRepository;
 
-	public Slice<Board> UserReviews(String nickname, Long cursorId, String sort) {
+	public Slice<Board> userReviews(String nickname, Long cursorId, String sort) {
 		Pageable pageable = PageRequest.of(0, 6);
 		log.info("nickname == {}", nickname);
 		log.info("cursorId == {}", cursorId);
@@ -49,12 +49,12 @@ public class UserReviewsService {
 				default:
 					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
 			}
-			
+
 			// 사용자의 게시글이 없는 경우 빈 Slice 반환
 			if (targetBoard == null) {
 				return new SliceImpl<>(new ArrayList<>(), pageable, false);
 			}
-			
+
 		} else {
 			targetBoard = boardRepository.findById(cursorId)
 				.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));

--- a/src/test/java/com/modureview/controller/UserReviewsControllerTest.java
+++ b/src/test/java/com/modureview/controller/UserReviewsControllerTest.java
@@ -1,0 +1,236 @@
+package com.modureview.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modureview.entity.Board;
+import com.modureview.entity.Category;
+import com.modureview.entity.User;
+import com.modureview.repository.UserReviewsRepository;
+import com.modureview.repository.UserRepository;
+import com.modureview.service.UserReviewsService;
+import com.modureview.utill.TestUtil;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("h2")
+class UserReviewsControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private UserReviewsService userReviewsService;
+  @Autowired
+  private UserReviewsRepository userReviewsRepository;
+  @Autowired
+  private UserRepository userRepository;
+
+  private TestUtil testUtil;
+
+  @BeforeEach
+  void setUp() {
+    this.testUtil = new TestUtil();
+    
+    User testUser = userRepository.save(testUtil.newUser("test@example.com"));
+    User otherUser = userRepository.save(testUtil.newUser("other@example.com"));
+    
+    List<Board> boards = new ArrayList<>();
+    
+    for (int i = 0; i < 5; i++) {
+      boards.add(
+          Board.builder()
+              .title("테스트 게시물 " + i)
+              .user(testUser)
+              .authorEmail("test@example.com")
+              .category(Category.car)
+              .content("<p>테스트 내용 " + i + "</p>")
+              .commentsCount(i * 2)
+              .bookmarksCount(i * 3)
+              .build()
+      );
+    }
+    
+    for (int i = 0; i < 3; i++) {
+      boards.add(
+          Board.builder()
+              .title("다른 사용자 게시물 " + i)
+              .user(otherUser)
+              .authorEmail("other@example.com")
+              .category(Category.food)
+              .content("<p>다른 사용자 내용 " + i + "</p>")
+              .commentsCount(i * 5)
+              .bookmarksCount(i * 4)
+              .build()
+      );
+    }
+    
+    userReviewsRepository.saveAll(boards);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    userReviewsRepository.deleteAll();
+    userRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("GET /users/{memberEmail} - recent 정렬로 사용자 리뷰 조회 성공")
+  void getUserReviews_Success_Recent() throws Exception {
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/users/test@example.com")
+                .param("cursor", "0")
+                .param("sort", "recent")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_000_000.0;
+    log.info("UserReviewsControllerTest.getUserReviews_Success_Recent() 실행 시간: {} ns ({} ms)",
+        duration, String.format("%.3f", durationMs));
+
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+  }
+
+  @Test
+  @DisplayName("GET /users/{memberEmail} - hotcomment 정렬로 사용자 리뷰 조회 성공")
+  void getUserReviews_Success_HotComment() throws Exception {
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/users/test@example.com")
+                .param("cursor", "0")
+                .param("sort", "hotcomment")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_000_000.0;
+    log.info("UserReviewsControllerTest.getUserReviews_Success_HotComment() 실행 시간: {} ns ({} ms)",
+        duration, String.format("%.3f", durationMs));
+
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+  }
+
+  @Test
+  @DisplayName("GET /users/{memberEmail} - hotbookmark 정렬로 사용자 리뷰 조회 성공")
+  void getUserReviews_Success_HotBookmark() throws Exception {
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/users/test@example.com")
+                .param("cursor", "0")
+                .param("sort", "hotbookmark")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_000_000.0;
+    log.info("UserReviewsControllerTest.getUserReviews_Success_HotBookmark() 실행 시간: {} ns ({} ms)",
+        duration, String.format("%.3f", durationMs));
+
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+  }
+
+  @Test
+  @DisplayName("GET /users/{memberEmail} - 존재하지 않는 사용자 이메일로 조회")
+  void getUserReviews_Success_NonExistentUser() throws Exception {
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/users/nonexistent@example.com")
+                .param("cursor", "0")
+                .param("sort", "recent")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_000_000.0;
+    log.info("UserReviewsControllerTest.getUserReviews_Success_NonExistentUser() 실행 시간: {} ns ({} ms)",
+        duration, String.format("%.3f", durationMs));
+
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+  }
+
+  @Test
+  @DisplayName("GET /users/{memberEmail} - 커서 기반 페이징 테스트")
+  void getUserReviews_Success_CursorPaging() throws Exception {
+    List<Board> savedBoards = userReviewsRepository.findAll();
+    Long existingBoardId = savedBoards.get(2).getId();
+    
+    long startTime = System.nanoTime();
+    MvcResult mvcResult = mockMvc.perform(
+            get("/users/test@example.com")
+                .param("cursor", existingBoardId.toString())
+                .param("sort", "recent")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime);
+    double durationMs = duration / 1_000_000.0;
+    log.info("UserReviewsControllerTest.getUserReviews_Success_CursorPaging() 실행 시간: {} ns ({} ms)",
+        duration, String.format("%.3f", durationMs));
+
+    String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(jsonObject);
+
+    log.info("Formatted JSON Response:");
+    log.info("prettyJson == {}", prettyJson);
+  }
+}

--- a/src/test/java/com/modureview/service/UserReviewsServiceTest.java
+++ b/src/test/java/com/modureview/service/UserReviewsServiceTest.java
@@ -1,0 +1,215 @@
+package com.modureview.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.modureview.entity.Board;
+import com.modureview.entity.Category;
+import com.modureview.enums.errors.BoardErrorCode;
+import com.modureview.exception.CustomException;
+import com.modureview.repository.UserReviewsRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+@ActiveProfiles("h2")
+class UserReviewsServiceTest {
+
+	@Autowired
+	private UserReviewsService userReviewsService;
+
+	@Autowired
+	private UserReviewsRepository userReviewsRepository;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		List<Board> boards = new ArrayList<>();
+
+		// user1의 게시글들
+		for (int i = 0; i < 5; i++) {
+			boards.add(
+				Board.builder()
+					.title("user1_게시글_" + i)
+					.authorEmail("user1@test.com")
+					.category(Category.book)
+					.content("<p>user1 내용 " + i + "</p>")
+					.commentsCount(i * 3)
+					.bookmarksCount(i * 5)
+					.build()
+			);
+		}
+
+		// user2의 게시글들 (구분용)
+		for (int i = 0; i < 3; i++) {
+			boards.add(
+				Board.builder()
+					.title("user2_게시글_" + i)
+					.authorEmail("user2@test.com")
+					.category(Category.car)
+					.content("<p>user2 내용 " + i + "</p>")
+					.commentsCount(i * 2)
+					.bookmarksCount(i * 4)
+					.build()
+			);
+		}
+
+		userReviewsRepository.saveAll(boards);
+		log.info("테스트 데이터 {} 개 생성 완료", boards.size());
+	}
+
+	@AfterEach
+	void cleanUp() {
+		userReviewsRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("초기 로딩 - recent 정렬 성공")
+	void UserReviews_Success_Recent_Initial() throws Exception {
+		String nickname = "user1";
+		Long cursorId = null;
+		String sort = "recent";
+
+		long startTime = System.nanoTime();
+		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		long endTime = System.nanoTime();
+
+		long duration = (endTime - startTime);
+		double durationMs = duration / 1_000_000.0;
+		log.info("UserReviews_Success_Recent_Initial() 실행 시간: {} ns ({} ms)", duration,
+			String.format("%.3f", durationMs));
+
+		String realJson = objectMapper
+			.enable(SerializationFeature.INDENT_OUTPUT)
+			.writeValueAsString(result);
+		log.info("realJson == {}", realJson);
+
+		assertThat(result.getContent()).hasSize(5);
+		//assertThat(result.getContent()).allMatch(board -> board.getAuthorNickname().equals("user1"))
+	}
+
+	@Test
+	@DisplayName("초기 로딩 - hotbookmarks 정렬 성공")
+	void UserReviews_Success_HotBookmarks_Initial() throws Exception {
+		String nickname = "user1";
+		Long cursorId = 0L;
+		String sort = "hotbookmarks";
+
+		long startTime = System.nanoTime();
+		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		long endTime = System.nanoTime();
+
+		long duration = (endTime - startTime);
+		double durationMs = duration / 1_000_000.0;
+		log.info("UserReviews_Success_HotBookmarks_Initial() 실행 시간: {} ns ({} ms)", duration,
+			String.format("%.3f", durationMs));
+
+		String realJson = objectMapper
+			.enable(SerializationFeature.INDENT_OUTPUT)
+			.writeValueAsString(result);
+		log.info("realJson == {}", realJson);
+
+		assertThat(result.getContent()).hasSize(5);
+		//assertThat(result.getContent()).allMatch(board -> board.getAuthorNickname().equals("user1"));
+	}
+
+	@Test
+	@DisplayName("초기 로딩 - hotcomments 정렬 성공")
+	void UserReviews_Success_HotComments_Initial() throws Exception {
+		String nickname = "user1";
+		Long cursorId = null;
+		String sort = "hotcomments";
+
+		long startTime = System.nanoTime();
+		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		long endTime = System.nanoTime();
+
+		long duration = (endTime - startTime);
+		double durationMs = duration / 1_000_000.0;
+		log.info("UserReviews_Success_HotComments_Initial() 실행 시간: {} ns ({} ms)", duration,
+			String.format("%.3f", durationMs));
+
+		String realJson = objectMapper
+			.enable(SerializationFeature.INDENT_OUTPUT)
+			.writeValueAsString(result);
+		log.info("realJson == {}", realJson);
+
+		assertThat(result.getContent()).hasSize(5);
+		//assertThat(result.getContent()).allMatch(board -> board.getAuthorNickname().equals("user1"));
+	}
+
+	@Test
+	@DisplayName("커서 기반 페이징 - recent 정렬 성공")
+	void UserReviews_Success_Recent_Cursor() throws Exception {
+		// 먼저 초기 로딩으로 첫 번째 게시글 가져오기
+		Slice<Board> firstPage = userReviewsService.UserReviews("user1", null, "recent");
+		Long cursorId = firstPage.getContent().get(0).getId();
+
+		String nickname = "user1";
+		String sort = "recent";
+
+		long startTime = System.nanoTime();
+		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		long endTime = System.nanoTime();
+
+		long duration = (endTime - startTime);
+		double durationMs = duration / 1_000_000.0;
+		log.info("UserReviews_Success_Recent_Cursor() 실행 시간: {} ns ({} ms)", duration,
+			String.format("%.3f", durationMs));
+
+		String realJson = objectMapper
+			.enable(SerializationFeature.INDENT_OUTPUT)
+			.writeValueAsString(result);
+		log.info("realJson == {}", realJson);
+
+		//assertThat(result.getContent()).allMatch(board -> board.getAuthorNickname().equals("user1"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 cursorId로 조회 시 예외 발생")
+	void UserReviews_Fail_InvalidCursorId() {
+		String nickname = "user1";
+		Long invalidCursorId = 999999L;
+		String sort = "recent";
+
+		assertThatThrownBy(() -> userReviewsService.UserReviews(nickname, invalidCursorId, sort))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", BoardErrorCode.BOARD_ID_NOTFOUND);
+
+		log.info("존재하지 않는 cursorId에 대한 예외 처리 확인 완료");
+	}
+
+	@Test
+	@DisplayName("다른 사용자 게시글은 조회되지 않음")
+	void UserReviews_Success_UserFilter() throws Exception {
+		String nickname = "user1";
+		Long cursorId = null;
+		String sort = "recent";
+
+		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+
+		assertThat(result.getContent()).hasSize(5);
+		//assertThat(result.getContent()).allMatch(board -> board.getAuthorNickname().equals("user1"));
+		//assertThat(result.getContent()).noneMatch(board -> board.getAuthorNickname().equals("user2"));
+
+		log.info("사용자별 게시글 필터링 확인 완료");
+	}
+}

--- a/src/test/java/com/modureview/service/UserReviewsServiceTest.java
+++ b/src/test/java/com/modureview/service/UserReviewsServiceTest.java
@@ -83,18 +83,18 @@ class UserReviewsServiceTest {
 
 	@Test
 	@DisplayName("초기 로딩 - recent 정렬 성공")
-	void UserReviews_Success_Recent_Initial() throws Exception {
+	void userReviews_Success_Recent_Initial() throws Exception {
 		String nickname = "user1";
 		Long cursorId = null;
 		String sort = "recent";
 
 		long startTime = System.nanoTime();
-		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		Slice<Board> result = userReviewsService.userReviews(nickname, cursorId, sort);
 		long endTime = System.nanoTime();
 
 		long duration = (endTime - startTime);
 		double durationMs = duration / 1_000_000.0;
-		log.info("UserReviews_Success_Recent_Initial() 실행 시간: {} ns ({} ms)", duration,
+		log.info("userReviews_Success_Recent_Initial() 실행 시간: {} ns ({} ms)", duration,
 			String.format("%.3f", durationMs));
 
 		String realJson = objectMapper
@@ -108,18 +108,18 @@ class UserReviewsServiceTest {
 
 	@Test
 	@DisplayName("초기 로딩 - hotbookmarks 정렬 성공")
-	void UserReviews_Success_HotBookmarks_Initial() throws Exception {
+	void userReviews_Success_HotBookmarks_Initial() throws Exception {
 		String nickname = "user1";
 		Long cursorId = 0L;
 		String sort = "hotbookmarks";
 
 		long startTime = System.nanoTime();
-		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		Slice<Board> result = userReviewsService.userReviews(nickname, cursorId, sort);
 		long endTime = System.nanoTime();
 
 		long duration = (endTime - startTime);
 		double durationMs = duration / 1_000_000.0;
-		log.info("UserReviews_Success_HotBookmarks_Initial() 실행 시간: {} ns ({} ms)", duration,
+		log.info("userReviews_Success_HotBookmarks_Initial() 실행 시간: {} ns ({} ms)", duration,
 			String.format("%.3f", durationMs));
 
 		String realJson = objectMapper
@@ -133,18 +133,18 @@ class UserReviewsServiceTest {
 
 	@Test
 	@DisplayName("초기 로딩 - hotcomments 정렬 성공")
-	void UserReviews_Success_HotComments_Initial() throws Exception {
+	void userReviews_Success_HotComments_Initial() throws Exception {
 		String nickname = "user1";
 		Long cursorId = null;
 		String sort = "hotcomments";
 
 		long startTime = System.nanoTime();
-		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		Slice<Board> result = userReviewsService.userReviews(nickname, cursorId, sort);
 		long endTime = System.nanoTime();
 
 		long duration = (endTime - startTime);
 		double durationMs = duration / 1_000_000.0;
-		log.info("UserReviews_Success_HotComments_Initial() 실행 시간: {} ns ({} ms)", duration,
+		log.info("userReviews_Success_HotComments_Initial() 실행 시간: {} ns ({} ms)", duration,
 			String.format("%.3f", durationMs));
 
 		String realJson = objectMapper
@@ -158,21 +158,21 @@ class UserReviewsServiceTest {
 
 	@Test
 	@DisplayName("커서 기반 페이징 - recent 정렬 성공")
-	void UserReviews_Success_Recent_Cursor() throws Exception {
+	void userReviews_Success_Recent_Cursor() throws Exception {
 		// 먼저 초기 로딩으로 첫 번째 게시글 가져오기
-		Slice<Board> firstPage = userReviewsService.UserReviews("user1", null, "recent");
+		Slice<Board> firstPage = userReviewsService.userReviews("user1", null, "recent");
 		Long cursorId = firstPage.getContent().get(0).getId();
 
 		String nickname = "user1";
 		String sort = "recent";
 
 		long startTime = System.nanoTime();
-		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		Slice<Board> result = userReviewsService.userReviews(nickname, cursorId, sort);
 		long endTime = System.nanoTime();
 
 		long duration = (endTime - startTime);
 		double durationMs = duration / 1_000_000.0;
-		log.info("UserReviews_Success_Recent_Cursor() 실행 시간: {} ns ({} ms)", duration,
+		log.info("userReviews_Success_Recent_Cursor() 실행 시간: {} ns ({} ms)", duration,
 			String.format("%.3f", durationMs));
 
 		String realJson = objectMapper
@@ -185,12 +185,12 @@ class UserReviewsServiceTest {
 
 	@Test
 	@DisplayName("존재하지 않는 cursorId로 조회 시 예외 발생")
-	void UserReviews_Fail_InvalidCursorId() {
+	void userReviews_Fail_InvalidCursorId() {
 		String nickname = "user1";
 		Long invalidCursorId = 999999L;
 		String sort = "recent";
 
-		assertThatThrownBy(() -> userReviewsService.UserReviews(nickname, invalidCursorId, sort))
+		assertThatThrownBy(() -> userReviewsService.userReviews(nickname, invalidCursorId, sort))
 			.isInstanceOf(CustomException.class)
 			.hasFieldOrPropertyWithValue("errorCode", BoardErrorCode.BOARD_ID_NOTFOUND);
 
@@ -199,12 +199,12 @@ class UserReviewsServiceTest {
 
 	@Test
 	@DisplayName("다른 사용자 게시글은 조회되지 않음")
-	void UserReviews_Success_UserFilter() throws Exception {
+	void UserReviews_Success_userFilter() throws Exception {
 		String nickname = "user1";
 		Long cursorId = null;
 		String sort = "recent";
 
-		Slice<Board> result = userReviewsService.UserReviews(nickname, cursorId, sort);
+		Slice<Board> result = userReviewsService.userReviews(nickname, cursorId, sort);
 
 		assertThat(result.getContent()).hasSize(5);
 		//assertThat(result.getContent()).allMatch(board -> board.getAuthorNickname().equals("user1"));


### PR DESCRIPTION

## 👀 제목
feat: 커서 기반 페이지네이션을 적용한 사용자 리뷰 조회 기능 구현

---

## 🙋 변경 사항
신규 기능 추가

---

## 💎 설명
특정 사용자가 작성한 모든 리뷰를 조회하는 기능을 구현했습니다.

* **API 엔드포인트 추가**: `GET /users/{memberEmail}`를 통해 특정 사용자의 리뷰를 조회할 수 있습니다.
* **커서 기반 페이지네이션 적용**: 대용량 데이터를 효율적으로 처리하기 위해 커서 기반 페이지네이션을 도입했습니다. 클라이언트는 현재 페이지의 마지막 아이템 ID를 커서 값으로 사용하여 다음 페이지를 요청할 수 있습니다.
* **정렬 기능**: 사용자는 세 가지 기준에 따라 리뷰를 정렬할 수 있습니다.
    * `recent`: 최신순
    * `hotbookmarks`: 인기순 (북마크 많은 순)
    * `hotcomments`: 댓글순 (댓글 많은 순)
* **아키텍처**: 기능 구현을 위해 `UserReviewsController`, `UserReviewsService`, `UserReviewsRepository`를 추가했습니다.

---

## 🔨 테스트 방법
새로운 기능의 안정성과 정확성을 보장하기 위해 통합 테스트와 서비스 테스트를 추가했습니다.

* **컨트롤러 테스트 (`UserReviewsControllerTest.java`)**
    * 다양한 정렬 옵션(`recent`, `hotcomment`, `hotbookmark`)에 따른 리뷰 조회 성공 케이스를 검증합니다.
    * 리뷰가 없는 사용자에 대한 요청 시, 빈 데이터를 정상적으로 반환하는지 테스트합니다.
    * 커서 기반 페이지네이션이 올바르게 동작하는지 확인합니다.
* **서비스 테스트 (`UserReviewsServiceTest.java`)**
    * 초기 로딩(커서가 없을 때)과 커서 기반의 후속 페이지 로딩 로직을 검증합니다.