### PR TITLE
Feat/users reviews

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,19 @@
-## 제목
+## 👀제목
 [Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"]
 
-## 변경 사항
+## 🙋변경 사항
 ex)새로운 기능 추가 
 
-## 설명
+## 💎설명
 [Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]
 
-## 테스트 방법
+## 🔨테스트 방법
 [Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]
 
-## 성능
+## ⚙성능
 [Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]
 
-## 추가 정보
+## ℹ️추가 정보
 [Any additional information that reviewers should be aware of.]
 
-## 이슈
+## ❌이슈

--- a/src/main/java/com/modureview/controller/UserReviewsController.java
+++ b/src/main/java/com/modureview/controller/UserReviewsController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.modureview.dto.response.CustomSlicePageResponse;
-import com.modureview.dto.response.SliceBoardResponse;
+import com.modureview.dto.response.UserReviewsResponse;
 import com.modureview.entity.Board;
 import com.modureview.service.UserReviewsService;
 
@@ -25,15 +25,17 @@ public class UserReviewsController {
 	private final UserReviewsService userReviewsService;
 
 	@GetMapping("/users/{memberEmail}")
-	public ResponseEntity<CustomSlicePageResponse<SliceBoardResponse>> getBoardsByUserEmail(
-		@PathVariable String memberEmail,
-		@RequestParam(name = "cursor", defaultValue = "0") Long cursor,
-		@RequestParam(name = "sort", defaultValue = "recent") String sort
-	) {
-		Slice<Board> boardSlice = userReviewsService.userReviews(memberEmail, cursor, sort);
-		List<SliceBoardResponse> dtoList = boardSlice.getContent().stream()
-			.map(SliceBoardResponse::fromEntity)
-			.collect(Collectors.toList());
+    public ResponseEntity<CustomSlicePageResponse<UserReviewsResponse>> getBoardsByUserEmail(
+        @PathVariable String memberEmail,
+        @RequestParam(name = "cursor", defaultValue = "0") Long cursor,
+        @RequestParam(name = "sort", defaultValue = "recent") String sort
+    ) {
+        Slice<Board> boardSlice = userReviewsService.userReviews(memberEmail, cursor, sort);
+        // Count total results for this author once and apply to all DTOs
+        long totalResults = userReviewsService.countByAuthorEmail(memberEmail);
+        List<UserReviewsResponse> dtoList = boardSlice.getContent().stream()
+            .map(board -> UserReviewsResponse.fromEntity(board, (int) totalResults))
+            .collect(Collectors.toList());
 
 		Long nextCursorValue = null;
 		if (boardSlice.hasNext() && !boardSlice.getContent().isEmpty()) {
@@ -41,14 +43,14 @@ public class UserReviewsController {
 			nextCursorValue = lastBoardInSlice.getId();
 		}
 
-		CustomSlicePageResponse<SliceBoardResponse> customResponse = new CustomSlicePageResponse<>(
-			dtoList,
-			nextCursorValue,
-			boardSlice.hasNext(),
-			boardSlice.getNumberOfElements(),
-			boardSlice.getSize(),
-			boardSlice.isFirst()
-		);
+        CustomSlicePageResponse<UserReviewsResponse> customResponse = new CustomSlicePageResponse<>(
+            dtoList,
+            nextCursorValue,
+            boardSlice.hasNext(),
+            boardSlice.getNumberOfElements(),
+            boardSlice.getSize(),
+            boardSlice.isFirst()
+        );
 
 		return ResponseEntity.ok(customResponse);
 	}

--- a/src/main/java/com/modureview/repository/UserReviewsRepository.java
+++ b/src/main/java/com/modureview/repository/UserReviewsRepository.java
@@ -52,4 +52,6 @@ public interface UserReviewsRepository extends JpaRepository<Board, Long> {
 
 	Board findTopByAuthorEmailOrderByCommentsCountDesc(String authorEmail);
 
+	long countByAuthorEmail(String authorEmail);
+
 }

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -75,4 +75,8 @@ public class UserReviewsService {
 			targetBoard.getId(), pageable);
 	}
 
+	public long countByAuthorEmail(String authorEmail) {
+		return userReviewsRepository.countByAuthorEmail(authorEmail);
+	}
+
 }


### PR DESCRIPTION
## 👀제목

사용자 리뷰 조회 기능 개선 및 SliceBoardResponse 변환 로직 적용

## 🙋변경 사항
	•	UserReviewsController에서 UserReviewsResponse 대신 SliceBoardResponse를 사용하도록 변경
	•	총 결과 개수를 각 DTO에서 개별 계산하는 로직 제거
	•	UserReviewsService에 countByAuthorEmail 메서드 추가
	•	UserReviewsRepository에 countByAuthorEmail 쿼리 메서드 추가

## 💎설명

이 PR은 사용자 리뷰 조회 API(GET /users/{memberEmail})의 응답 구조와 내부 로직을 개선하는 작업입니다.
기존에는 UserReviewsResponse를 사용하면서 총 결과 개수를 모든 DTO 변환 시 매번 전달했으나, 이를 제거하고 SliceBoardResponse로 단순화했습니다.
또한, 총 개수 조회는 UserReviewsService에서 필요한 경우 호출할 수 있도록 메서드를 추가했습니다.
이로써 응답 변환 로직이 간결해지고, 불필요한 연산을 줄여 성능과 가독성을 개선했습니다.

## 🔨테스트 방법
	1.	/users/{memberEmail} 엔드포인트 호출 시 정상적으로 SliceBoardResponse 형식의 데이터가 반환되는지 확인
	2.	cursor 및 sort 파라미터 조합에 따라 페이징과 정렬이 올바르게 작동하는지 검증
	3.	데이터가 다음 페이지로 이어질 경우 nextCursor 값이 정상적으로 반환되는지 확인
	4.	UserReviewsService.countByAuthorEmail 호출 결과가 정확한지 단위 테스트로 검증
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/cf7dafeb-fb0d-4d05-a880-bbffe88a03fa" />


## ⚙성능
	•	불필요한 총 개수 연산 제거로 DTO 변환 시 성능 소폭 개선
	•	데이터 조회 시 불필요한 연산이 줄어 API 응답 속도가 향상될 가능성 있음

## ℹ추가 정보
	•	추후 총 개수를 반드시 반환해야 하는 요구사항이 생기면, countByAuthorEmail 메서드를 활용하여 컨트롤러 단에서 처리 가능
	•	SliceBoardResponse 적용으로 코드 일관성이 향상됨

## ❌이슈
	•	없음
