### PR TITLE
Feat/notification service

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,19 @@
-## 제목
+## 👀제목
 [Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"]
 
-## 변경 사항
+## 🙋변경 사항
 ex)새로운 기능 추가 
 
-## 설명
+## 💎설명
 [Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]
 
-## 테스트 방법
+## 🔨테스트 방법
 [Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]
 
-## 성능
+## ⚙성능
 [Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]
 
-## 추가 정보
+## ℹ️추가 정보
 [Any additional information that reviewers should be aware of.]
 
-## 이슈
+## ❌이슈

--- a/src/main/java/com/modureview/controller/NotificationController.java
+++ b/src/main/java/com/modureview/controller/NotificationController.java
@@ -1,0 +1,94 @@
+package com.modureview.controller;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.modureview.dto.request.NotificationRequest;
+import com.modureview.dto.response.CustomPageResponse;
+import com.modureview.dto.response.NotificationPushResponse;
+import com.modureview.service.NotificationService;
+import com.modureview.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/users/me/notifications")
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationController {
+	private final NotificationService notificationService;
+	private final UserService userService;
+
+	@GetMapping
+	public ResponseEntity<CustomPageResponse<NotificationPushResponse>> getAllNotifications(
+		@CookieValue("userEmail")String userEmail,
+		@RequestParam(defaultValue = "1") int page
+	){
+		Long userId = userService.findUserId(userEmail);
+		 log.info("알람 목록 조회 요청 - 사용자 이메일 : {} , ID : {} ", userEmail, userId);
+		Page<NotificationPushResponse> result = notificationService.getNotifications(userId, page);
+
+		List<NotificationPushResponse> results = result.getContent();
+		CustomPageResponse<NotificationPushResponse> resp = new CustomPageResponse<>(
+			results,
+			result.getNumber()+1,
+			result.getTotalPages()
+		);
+
+
+		 return ResponseEntity.ok(resp);
+	}
+
+	@GetMapping("/unread")
+	public ResponseEntity<Boolean> hasUnread(@CookieValue("userEmail")String userEmail){
+		Long userId = userService.findUserId(userEmail);
+		boolean exists = notificationService.hasUnread(userId);
+		return ResponseEntity.ok(exists);
+	}
+
+	@PatchMapping("/{notificationId}")
+	public ResponseEntity<Void> updateNotification(
+		@PathVariable Long notificationId,
+		@CookieValue("userEmail") String userEmail,
+		@RequestBody NotificationRequest request
+	){
+		if(request == null){
+			return ResponseEntity.badRequest().build();
+		}
+		Long userId = userService.findUserId(userEmail);
+
+		boolean read = request.isRead();
+		boolean delete = request.isDelete();
+
+
+		if (read == delete ){
+			log.warn("잘못된 알림 업데이트 요청 - notificationId : {} , read: {} , delete: {} ", notificationId, read, delete);
+			return ResponseEntity.badRequest().build();
+		}
+		if(delete){
+			notificationService.markAsDeleted(notificationId);
+		}else{
+			notificationService.markAsRead(notificationId);
+		}
+		return ResponseEntity.ok().build();
+
+
+	}
+}

--- a/src/main/java/com/modureview/dto/request/NotificationRequest.java
+++ b/src/main/java/com/modureview/dto/request/NotificationRequest.java
@@ -1,0 +1,7 @@
+package com.modureview.dto.request;
+
+public record NotificationRequest(
+	boolean isRead,
+	boolean isDelete
+) {
+}

--- a/src/main/java/com/modureview/dto/response/NotificationPushResponse.java
+++ b/src/main/java/com/modureview/dto/response/NotificationPushResponse.java
@@ -1,0 +1,30 @@
+package com.modureview.dto.response;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.modureview.entity.Notification;
+
+public record NotificationPushResponse(
+	Long id,
+	Long board_id,
+	String type,
+	String title,
+	boolean isRead,
+	boolean isDeleted,
+	@JsonProperty("created_at")
+	@JsonFormat(pattern = "MM월 dd일 HH시 mm분",timezone = "Asia/Seoul")
+	LocalDateTime createdAt
+	) {
+		public static NotificationPushResponse from(Notification notification,String title) {
+			return new NotificationPushResponse(
+				notification.getId(),
+				notification.getBoardId(),
+				notification.getNotificationType().name(),
+				title,
+				notification.isRead(),
+				notification.isDeleted(),
+				notification.getCreatedAt()
+			);
+		}
+	}

--- a/src/main/java/com/modureview/entity/Notification.java
+++ b/src/main/java/com/modureview/entity/Notification.java
@@ -1,0 +1,70 @@
+package com.modureview.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Notification {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long receiverUserId;
+	private Long senderUserId;
+	private Long boardId;
+
+	@Enumerated(EnumType.STRING)
+	private NotificationType notificationType;
+
+	private boolean isRead = false;
+	private boolean isDeleted = false;
+
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@Column(name = "modified_at")
+	private LocalDateTime modifiedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.modifiedAt = LocalDateTime.now();
+	}
+
+	@Builder
+	public Notification(Long receiverUserId, Long senderUserId, Long boardId,
+		NotificationType notificationType, String message) {
+		this.receiverUserId = receiverUserId;
+		this.senderUserId = senderUserId;
+		this.boardId = boardId;
+		this.notificationType = notificationType;
+	}
+
+	public void markAsRead() {
+		this.isRead = true;
+	}
+	public void markAsDeleted() {
+		this.isDeleted = true;
+	}
+
+
+
+}

--- a/src/main/java/com/modureview/entity/NotificationType.java
+++ b/src/main/java/com/modureview/entity/NotificationType.java
@@ -1,0 +1,14 @@
+package com.modureview.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationType {
+	bookmark("북마크"), comment("댓글");
+
+	private final String description;
+
+	NotificationType(String description) {
+		this.description = description;
+	}
+}

--- a/src/main/java/com/modureview/mapper/NotificationMapper.java
+++ b/src/main/java/com/modureview/mapper/NotificationMapper.java
@@ -1,0 +1,38 @@
+package com.modureview.mapper;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.modureview.dto.response.NotificationPushResponse;
+import com.modureview.entity.Notification;
+
+public class NotificationMapper {
+	private static final int TITLE_LIMIT = 15;
+
+	private NotificationMapper(){}
+
+	public static Page<NotificationPushResponse> toResponsePage(
+		Page<Notification> page, Function<Long , String> titleResolver
+	) {
+		List<NotificationPushResponse> content = page.getContent().stream()
+			.map(n -> NotificationPushResponse.from(
+				n, ellipsize(titleResolver.apply(n.getBoardId()), TITLE_LIMIT)
+			)).toList();
+
+		return new PageImpl<>(content, page.getPageable(), page.getTotalElements());
+	}
+
+	private static String ellipsize(String s , int limit) {
+		if(s == null )
+			return "";
+		int count = s.codePointCount(0, s.length());
+		if(count < limit ) return s;
+		int endIndex = s.offsetByCodePoints(0, limit);
+		return s.substring(0, endIndex) + "...";
+	}
+
+
+}

--- a/src/main/java/com/modureview/repository/NotificationRepository.java
+++ b/src/main/java/com/modureview/repository/NotificationRepository.java
@@ -1,0 +1,23 @@
+package com.modureview.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.modureview.entity.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+	@Query("SELECT n FROM Notification n WHERE n.receiverUserId = :userId AND n.isDeleted = false ORDER BY n.createdAt DESC")
+	List<Notification> findActiveNotifications(@Param("userId") Long userId);
+
+	@Query("SELECT COUNT(n) FROM Notification n WHERE n.receiverUserId = :userId AND n.isRead = false AND n.isDeleted = false")
+	int countUnreadNotifications(@Param("userId") Long userId);
+
+	Page<Notification> findByReceiverUserIdAndIsDeletedFalse(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/modureview/service/NotificationService.java
+++ b/src/main/java/com/modureview/service/NotificationService.java
@@ -1,0 +1,135 @@
+package com.modureview.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.modureview.dto.response.NotificationPushResponse;
+import com.modureview.entity.Board;
+import com.modureview.entity.Notification;
+import com.modureview.entity.NotificationType;
+import com.modureview.enums.errors.BoardErrorCode;
+import com.modureview.enums.errors.UserErrorCode;
+import com.modureview.exception.CustomException;
+import com.modureview.mapper.NotificationMapper;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.NotificationRepository;
+import com.modureview.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+	private final NotificationRepository notificationRepository;
+	private final UserRepository userRepository;
+	private final BoardRepository boardRepository;
+
+	@Transactional
+	public NotificationPushResponse sendNotification(Long receiverUserId,Long senderUserId,Long boardId,
+		NotificationType type) {
+		userRepository.findById(receiverUserId).orElseThrow(
+			() -> new CustomException(UserErrorCode.USER_NOT_FOUND)
+		);
+		Notification notification = Notification.builder()
+			.receiverUserId(receiverUserId)
+			.senderUserId(senderUserId)
+			.boardId(boardId)
+			.notificationType(type)
+			.build();
+		notificationRepository.save(notification);
+		//sseService.sendNotificaion(receiverUserId , NotificaionPushResponse.from(notificaion));
+		Board targetBoard = boardRepository.findById(boardId)
+			.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
+		return NotificationPushResponse.from(notification, targetBoard.getTitle());
+	}
+
+	/*@Transactional(readOnly = true)
+	public List<NotificationPushResponse> getActiveNotifications(Long userId,int page) {
+		List<Notification> notifications = notificationRepository.findActiveNotifications(userId);
+		if (notifications.isEmpty())
+			return List.of();
+
+		List<Long> boardIds = notifications.stream()
+			.map(Notification::getBoardId)
+			.distinct()
+			.toList();
+
+		Map<Long, Board> boardMap = boardRepository.findAllById(boardIds)
+			.stream()
+			.collect(Collectors.toMap(Board::getId, b -> b));
+
+		return notifications.stream()
+			.map(n -> {
+				Board b = boardMap.get(n.getBoardId());
+				String title = (b != null) ? b.getTitle() : "원본 게시물이 없음";
+				title = ellipsize(title, 15);
+				return NotificationPushResponse.from(n, title);
+			})
+			.toList();
+	}*/
+
+	@Transactional(readOnly = true)
+	public Page<NotificationPushResponse> getNotifications(Long userId,int page) {
+		Pageable pageable = PageRequest.of(page -1 , 12 , Sort.by(Sort.Direction.DESC, "createdAt"));
+
+		Page<Notification> result = notificationRepository.findByReceiverUserIdAndIsDeletedFalse(userId, pageable);
+
+		if(result.isEmpty()){
+			return new PageImpl<>(List.of(),pageable,0);
+		}
+
+		List<Long> boardIds = result.getContent().stream()
+			.map(Notification::getBoardId)
+			.filter(Objects::nonNull)
+			.distinct()
+			.toList();
+
+		Map<Long, String> titleMap = boardRepository.findAllById(boardIds).stream()
+			.collect(Collectors.toMap(Board::getId, Board::getTitle));
+
+		Function<Long , String> titleResolver =
+			id -> titleMap.getOrDefault(id, "원본 게시물이 없음");
+
+		return NotificationMapper.toResponsePage(result, titleResolver);
+	}
+
+	@Transactional
+	public void markAsRead(Long notificationId) {
+		notificationRepository.findById(notificationId).ifPresent(Notification::markAsRead);
+	}
+
+	@Transactional
+	public void markAsDeleted(Long notificationId) {
+		notificationRepository.findById(notificationId).ifPresent(Notification::markAsDeleted);
+	}
+
+	private static String ellipsize(String s , int limit){
+		if(s == null ) return "";
+		int count = s.codePointCount(0, s.length());
+		if(count < limit) return s;
+		int endIndex = s.offsetByCodePoints(0, limit);
+		return s.substring(0, endIndex) + "...";
+	}
+
+	@Transactional(readOnly = true)
+	public boolean hasUnread(Long userId){
+		return notificationRepository.countUnreadNotifications(userId) > 0;
+	}
+
+
+
+
+}

--- a/src/main/java/com/modureview/service/NotificationService.java
+++ b/src/main/java/com/modureview/service/NotificationService.java
@@ -50,36 +50,10 @@ public class NotificationService {
 			.notificationType(type)
 			.build();
 		notificationRepository.save(notification);
-		//sseService.sendNotificaion(receiverUserId , NotificaionPushResponse.from(notificaion));
 		Board targetBoard = boardRepository.findById(boardId)
 			.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
 		return NotificationPushResponse.from(notification, targetBoard.getTitle());
 	}
-
-	/*@Transactional(readOnly = true)
-	public List<NotificationPushResponse> getActiveNotifications(Long userId,int page) {
-		List<Notification> notifications = notificationRepository.findActiveNotifications(userId);
-		if (notifications.isEmpty())
-			return List.of();
-
-		List<Long> boardIds = notifications.stream()
-			.map(Notification::getBoardId)
-			.distinct()
-			.toList();
-
-		Map<Long, Board> boardMap = boardRepository.findAllById(boardIds)
-			.stream()
-			.collect(Collectors.toMap(Board::getId, b -> b));
-
-		return notifications.stream()
-			.map(n -> {
-				Board b = boardMap.get(n.getBoardId());
-				String title = (b != null) ? b.getTitle() : "원본 게시물이 없음";
-				title = ellipsize(title, 15);
-				return NotificationPushResponse.from(n, title);
-			})
-			.toList();
-	}*/
 
 	@Transactional(readOnly = true)
 	public Page<NotificationPushResponse> getNotifications(Long userId,int page) {
@@ -114,14 +88,6 @@ public class NotificationService {
 	@Transactional
 	public void markAsDeleted(Long notificationId) {
 		notificationRepository.findById(notificationId).ifPresent(Notification::markAsDeleted);
-	}
-
-	private static String ellipsize(String s , int limit){
-		if(s == null ) return "";
-		int count = s.codePointCount(0, s.length());
-		if(count < limit) return s;
-		int endIndex = s.offsetByCodePoints(0, limit);
-		return s.substring(0, endIndex) + "...";
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -35,7 +35,6 @@ public class UserReviewsService {
 		Board targetBoard;
 
 		if (cursorId == null || cursorId == 0L) {
-			// 초기 로딩: 해당 사용자의 최신/최다 게시글 찾기
 			switch (sort) {
 				case "recent":
 					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);

--- a/src/test/java/com/modureview/controller/NotificationControllerTest.java
+++ b/src/test/java/com/modureview/controller/NotificationControllerTest.java
@@ -1,0 +1,275 @@
+package com.modureview.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modureview.dto.response.NotificationPushResponse;
+import com.modureview.entity.Board;
+import com.modureview.entity.Notification;
+import com.modureview.entity.User;
+import com.modureview.entity.NotificationType;
+import com.modureview.repository.BoardRepository;
+import com.modureview.repository.NotificationRepository;
+import com.modureview.repository.UserRepository;
+import com.modureview.utill.TestUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.transaction.Transactional;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+@ActiveProfiles("h2")
+class NotificationControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private UserRepository userRepository;
+  @Autowired private BoardRepository boardRepository;
+  @Autowired private NotificationRepository notificationRepository;
+
+  private TestUtil testUtil;
+  private String userEmail;
+  private Long userId;
+  private String emptyUserEmail;
+  private Long emptyUserId;
+  private Board board;
+  private Notification unreadNotification;
+  private Notification readNotification;
+
+  @BeforeEach
+  void setUp() {
+    testUtil = new TestUtil();
+    userEmail = "notify@test.com";
+    emptyUserEmail = "empty@test.com";
+
+    // 사용자/게시글 준비
+    User user = userRepository.save(testUtil.newUser(userEmail));
+    userId = user.getId();
+
+    // 빈 사용자(알림 없음)
+    User emptyUser = userRepository.save(testUtil.newUser(emptyUserEmail));
+    emptyUserId = emptyUser.getId();
+
+    board = testUtil.newBoard(user);
+    // 길이가 15자를 넘도록 제목 조정 (절단 확인)
+    // 기본 TestUtil 제목은 "테스트"이므로 덮어쓰지 못해 여기서 저장 후 타이틀을 수정하여 다시 저장할 수 없으므로
+    // 아예 새 Board를 생성하여 긴 제목으로 저장한다.
+    board = Board.builder()
+        .title("아주아주아주아주긴제목확인용타이틀")
+        .user(user)
+        .authorEmail(user.getEmail())
+        .category(com.modureview.entity.Category.car)
+        .content("<p>content</p>")
+        .commentsCount(0)
+        .bookmarksCount(0)
+        .build();
+    board = boardRepository.save(board);
+
+    // 알림 2건 생성: 하나는 unread, 하나는 read
+    unreadNotification = notificationRepository.save(
+        Notification.builder()
+            .receiverUserId(userId)
+            .senderUserId(userId)
+            .boardId(board.getId())
+              .notificationType(NotificationType.comment)
+            .build());
+
+    readNotification = notificationRepository.save(
+        Notification.builder()
+            .receiverUserId(userId)
+            .senderUserId(userId)
+            .boardId(board.getId())
+              .notificationType(NotificationType.bookmark)
+            .build());
+    // 읽음 처리
+    readNotification.markAsRead();
+    notificationRepository.save(readNotification);
+  }
+
+  @Test
+  @DisplayName("GET /users/me/notifications - 빈 상태일 때 빈 배열 반환")
+  void getNotifications_empty_list() throws Exception {
+    log.info("[REQ] GET /users/me/notifications cookie=userEmail={}", emptyUserEmail);
+    MvcResult res = mockMvc.perform(
+            get("/users/me/notifications")
+                .cookie(new Cookie("userEmail", emptyUserEmail))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String body = res.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    // Pretty JSON logging
+    Object jsonObjectEmpty = objectMapper.readValue(body, Object.class);
+    String prettyJsonEmpty = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObjectEmpty);
+    log.info("[EMPTY LIST] Response Body (pretty):\n{}", prettyJsonEmpty);
+    Map<String, Object> root = objectMapper.readValue(body, new TypeReference<Map<String, Object>>() {});
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> results = (List<Map<String, Object>>) root.get("results");
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  @DisplayName("GET /users/me/notifications - 목록 조회 및 제목 15자 절단 확인")
+  void getNotifications_list_with_title_ellipsis() throws Exception {
+    log.info("[REQ] GET /users/me/notifications cookie=userEmail={}", userEmail);
+    MvcResult res = mockMvc.perform(
+            get("/users/me/notifications")
+                .cookie(new Cookie("userEmail", userEmail))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String body = res.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    // Pretty JSON logging
+    Object jsonObjectList = objectMapper.readValue(body, Object.class);
+    String prettyJsonList = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObjectList);
+    log.info("[LIST ELLIPSIS] Response Body (pretty):\n{}", prettyJsonList);
+    Map<String, Object> root = objectMapper.readValue(body, new TypeReference<Map<String, Object>>() {});
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> results = (List<Map<String, Object>>) root.get("results");
+
+    assertThat(results).isNotEmpty();
+    // 제목 절단 규칙: 15자 + "..." 붙음 (한글 code point 기준 절단 가정)
+    String title = (String) results.get(0).get("title");
+    assertThat(title.length()).isGreaterThanOrEqualTo(3);
+    assertThat(title).endsWith("...");
+  }
+
+  @Test
+  @DisplayName("GET /users/me/notifications - 최소 7건 이상 목록 반환")
+  void getNotifications_list_with_seven_items() throws Exception {
+    // 추가 알림 7건 생성
+    for (int i = 0; i < 7; i++) {
+      notificationRepository.save(
+          Notification.builder()
+              .receiverUserId(userId)
+              .senderUserId(userId)
+              .boardId(board.getId())
+              .notificationType(NotificationType.comment)
+              .build());
+    }
+
+    log.info("[REQ] GET /users/me/notifications cookie=userEmail={}", userEmail);
+    MvcResult res = mockMvc.perform(
+            get("/users/me/notifications")
+                .cookie(new Cookie("userEmail", userEmail))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String body = res.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    // Pretty JSON logging
+    Object jsonObjectSeven = objectMapper.readValue(body, Object.class);
+    String prettyJsonSeven = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObjectSeven);
+    log.info("[LIST >=7] Response Body (pretty):\n{}", prettyJsonSeven);
+    Map<String, Object> root = objectMapper.readValue(body, new TypeReference<Map<String, Object>>() {});
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> results = (List<Map<String, Object>>) root.get("results");
+
+    assertThat(results.size()).isGreaterThanOrEqualTo(7);
+    // 일부 항목 필드 점검
+    Map<String, Object> first = results.get(0);
+    Long respBoardId = ((Number) first.get("board_id")).longValue();
+    assertThat(respBoardId).isEqualTo(board.getId());
+    assertThat((String) first.get("title")).endsWith("...");
+  }
+
+  @Test
+  @DisplayName("GET /users/me/notifications/unread - unread 존재 여부 true")
+  void unread_exists_true() throws Exception {
+    log.info("[REQ] GET /users/me/notifications/unread cookie=userEmail={}", userEmail);
+    MvcResult res = mockMvc.perform(
+            get("/users/me/notifications/unread")
+                .cookie(new Cookie("userEmail", userEmail))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String body = res.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    // Pretty JSON logging (boolean)
+    Object jsonObjectUnread = objectMapper.readValue(body, Object.class);
+    String prettyJsonUnread = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObjectUnread);
+    log.info("[UNREAD EXISTS] Response Body (pretty):\n{}", prettyJsonUnread);
+    Boolean exists = objectMapper.readValue(body, Boolean.class);
+    assertThat(exists).isTrue();
+  }
+
+  @Test
+  @DisplayName("PATCH /users/me/notifications/{id} - isRead=true 처리")
+  void patch_mark_read() throws Exception {
+    Map<String, Object> req = new HashMap<>();
+    req.put("isRead", true);
+    String reqJson = objectMapper.writeValueAsString(req);
+    log.info("[REQ] PATCH /users/me/notifications/{} cookie=userEmail={}\nBody: {}",
+        unreadNotification.getId(), userEmail, reqJson);
+
+    mockMvc.perform(
+            patch("/users/me/notifications/{id}", unreadNotification.getId())
+                .cookie(new Cookie("userEmail", userEmail))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqJson))
+        .andExpect(status().isOk());
+
+    // 확인: 해당 알림이 읽음 처리되었는지
+    Notification n = notificationRepository.findById(unreadNotification.getId()).orElseThrow();
+    assertThat(n.isRead()).isTrue();
+  }
+
+  @Test
+  @DisplayName("PATCH /users/me/notifications/{id} - isDelete=true 처리")
+  void patch_mark_delete() throws Exception {
+    Map<String, Object> req = new HashMap<>();
+    req.put("isDelete", true);
+    String reqJson = objectMapper.writeValueAsString(req);
+    log.info("[REQ] PATCH /users/me/notifications/{} cookie=userEmail={}\nBody: {}",
+        unreadNotification.getId(), userEmail, reqJson);
+
+    mockMvc.perform(
+            patch("/users/me/notifications/{id}", unreadNotification.getId())
+                .cookie(new Cookie("userEmail", userEmail))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqJson))
+        .andExpect(status().isOk());
+
+    Notification n = notificationRepository.findById(unreadNotification.getId()).orElseThrow();
+    assertThat(n.isDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("PATCH /users/me/notifications/{id} - 잘못된 요청(둘 다 true) → 400")
+  void patch_invalid_both_true() throws Exception {
+    Map<String, Object> req = new HashMap<>();
+    req.put("isRead", true);
+    req.put("isDelete", true);
+    String reqJson = objectMapper.writeValueAsString(req);
+    log.info("[REQ] PATCH /users/me/notifications/{} cookie=userEmail={}\nBody: {}",
+        unreadNotification.getId(), userEmail, reqJson);
+
+    mockMvc.perform(
+            patch("/users/me/notifications/{id}", unreadNotification.getId())
+                .cookie(new Cookie("userEmail", userEmail))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqJson))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
## 👀제목  
Notification Service 기능 추가 및 API 구현 (SSE 연동 예정)

## 🙋변경 사항  
- Notification 엔티티, 타입(Enum), Repository, Service, Controller 신규 구현  
- 알림 목록 조회, 읽음/삭제 처리, 읽지 않은 알림 여부 조회 API 추가  
- 제목 절단 로직(15자 + …) 적용  
- NotificationMapper를 통해 Page<Notification> → Page<NotificationPushResponse> 변환 기능 구현  
- PR 템플릿 문구 개선 (이모지 및 구체적 안내 추가)  
- Notification 관련 통합 테스트(`NotificationControllerTest`) 추가

## 💎설명  
이번 PR에서는 사용자 알림(Notification) 기능의 전반적인 구조를 구현했습니다.  
- **엔티티**: `Notification` 클래스 및 `NotificationType` Enum 정의  
- **DTO**: 알림 요청(`NotificationRequest`), 알림 응답(`NotificationPushResponse`)  
- **Repository**: 알림 목록 조회, 읽지 않은 알림 개수 조회 쿼리 추가  
- **Service**: 알림 발송, 목록 조회, 읽음/삭제 처리, 읽지 않은 알림 여부 확인 기능 구현  
- **Controller**: `/users/me/notifications` 관련 REST API 엔드포인트 3종 구현 (목록 조회, 읽지 않은 알림 여부 확인, 읽음/삭제 처리)  
- **Mapper**: 제목 절단 처리 포함한 매핑 로직 구현  
- **테스트 코드**: MockMvc 기반 API 통합 테스트 작성 (빈 목록, 제목 절단 여부, 최소 목록 수, 읽음/삭제 처리, 잘못된 요청 검증)  

추후 SSE 기반 실시간 알림 전송 로직이 추가될 예정입니다.

## 🔨테스트 방법  
- H2 인메모리 DB 환경에서 `NotificationControllerTest` 실행  
- 시나리오별 테스트:
  1. 빈 사용자 알림 목록 → 빈 배열 반환
  2. 알림 제목 15자 절단 + "..." 처리 여부 검증
  3. 알림 목록 7건 이상 반환 여부 검증
  4. 읽지 않은 알림 여부(Boolean) 반환 검증
  5. PATCH 요청으로 읽음/삭제 처리 성공 여부 확인
  6. PATCH 요청에 `isRead`와 `isDelete`가 동시에 true인 경우 400 반환 검증
  
  
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/eef9f12a-285e-4bbb-aaa3-42334c6668c5" />

  
  

## ⚙성능  
- 페이지네이션(PageRequest, size=12) 적용으로 대량 알림 조회 시 성능 최적화  
- 필요 시 Board 제목을 한 번에 조회하기 위해 ID 목록 기반 `findAllById` 사용  
- 제목 절단 시 문자열 코드 포인트 기준 처리로 다국어 환경 대응

## ℹ추가 정보  
- SSE 연동 시 `sendNotification` 메서드에서 주석 처리된 SSE 전송 부분 활성화 예정  
- 테스트에서는 필터를 비활성화(`@AutoConfigureMockMvc(addFilters = false)`)하여 인증 절차 없이 API 동작 검증  
- Board 제목 절단 로직은 NotificationMapper와 Service 내부에서 각각 적용 가능하나, 현재는 Mapper에서 일괄 처리

## ❌이슈  
- SSE 기능 미구현 (추가 개발 필요)  
- 실서비스 환경에서 인증/인가 처리 로직 연동 필요