### PR TITLE
Feat/UsersReviews

### DIFF
--- a/src/main/java/com/modureview/config/SecurityConfig.java
+++ b/src/main/java/com/modureview/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
                 "/reviews/*/bookmarks",
                 "/search",
                 "/users/login",
-                "favicon.io"
+                "favicon.io",
+                "/users/**"
             )
             .permitAll()
             .requestMatchers("/reviews/**")

--- a/src/main/java/com/modureview/controller/UserReviewsController.java
+++ b/src/main/java/com/modureview/controller/UserReviewsController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.modureview.dto.response.CustomSlicePageResponse;
-import com.modureview.dto.response.UserReviewsResponse;
+import com.modureview.dto.response.SliceBoardResponse;
 import com.modureview.entity.Board;
 import com.modureview.service.UserReviewsService;
 
@@ -25,16 +25,14 @@ public class UserReviewsController {
 	private final UserReviewsService userReviewsService;
 
 	@GetMapping("/users/{memberEmail}")
-    public ResponseEntity<CustomSlicePageResponse<UserReviewsResponse>> getBoardsByUserEmail(
+    public ResponseEntity<CustomSlicePageResponse<SliceBoardResponse>> getBoardsByUserEmail(
         @PathVariable String memberEmail,
         @RequestParam(name = "cursor", defaultValue = "0") Long cursor,
         @RequestParam(name = "sort", defaultValue = "recent") String sort
     ) {
         Slice<Board> boardSlice = userReviewsService.userReviews(memberEmail, cursor, sort);
-        // Count total results for this author once and apply to all DTOs
-        long totalResults = userReviewsService.countByAuthorEmail(memberEmail);
-        List<UserReviewsResponse> dtoList = boardSlice.getContent().stream()
-            .map(board -> UserReviewsResponse.fromEntity(board, (int) totalResults))
+        List<SliceBoardResponse> dtoList = boardSlice.getContent().stream()
+            .map(SliceBoardResponse::fromEntity)
             .collect(Collectors.toList());
 
 		Long nextCursorValue = null;
@@ -43,15 +41,15 @@ public class UserReviewsController {
 			nextCursorValue = lastBoardInSlice.getId();
 		}
 
-        CustomSlicePageResponse<UserReviewsResponse> customResponse = new CustomSlicePageResponse<>(
-            dtoList,
-            nextCursorValue,
-            boardSlice.hasNext(),
-            boardSlice.getNumberOfElements(),
-            boardSlice.getSize(),
-            boardSlice.isFirst()
-        );
+        Long totalResults = userReviewsService.countByAuthorEmail(memberEmail);
 
-		return ResponseEntity.ok(customResponse);
+		CustomSlicePageResponse<SliceBoardResponse> body = CustomSlicePageResponse.of(
+			dtoList,
+			nextCursorValue,
+			boardSlice.hasNext(),
+			totalResults
+		);
+
+		return ResponseEntity.ok(body);
 	}
 }

--- a/src/main/java/com/modureview/controller/UserReviewsController.java
+++ b/src/main/java/com/modureview/controller/UserReviewsController.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserReviewsController {
 	private final UserReviewsService userReviewsService;
 
-	@GetMapping("/users/{memberEmail}")
+	@GetMapping("/users/{memberEmail}/reviews")
     public ResponseEntity<CustomSlicePageResponse<SliceBoardResponse>> getBoardsByUserEmail(
         @PathVariable String memberEmail,
         @RequestParam(name = "cursor", defaultValue = "0") Long cursor,

--- a/src/main/java/com/modureview/dto/response/CustomSlicePageResponse.java
+++ b/src/main/java/com/modureview/dto/response/CustomSlicePageResponse.java
@@ -1,21 +1,39 @@
 package com.modureview.dto.response;
 
 import java.util.List;
+
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@Builder
+
 public class CustomSlicePageResponse<T> {
 
   private final List<T> results;
   private final Long next_cursor;
   private final boolean has_next;
+  private final Long total_results;
 
-
-  public CustomSlicePageResponse(List<T> results, Long next_cursor, boolean has_next,
-      int numberOfElements, int size, boolean first) {
-    this.results = results;
-    this.next_cursor = next_cursor;
-    this.has_next = has_next;
+  public static <T> CustomSlicePageResponse<T> of(List<T> results, Long next_cursor, boolean has_next) {
+    return CustomSlicePageResponse.<T>builder()
+        .results(results)
+        .next_cursor(next_cursor)
+        .has_next(has_next)
+        .build();
   }
+
+  public static <T> CustomSlicePageResponse<T> of(
+      List<T> results , Long next_cursor , boolean has_next , Long total_results
+  ){
+    return CustomSlicePageResponse.<T>builder()
+        .results(results)
+        .next_cursor(next_cursor)
+        .has_next(has_next)
+        .total_results(total_results)
+        .build();
+  }
+
 }
 

--- a/src/main/java/com/modureview/filter/JwtAuthFilter.java
+++ b/src/main/java/com/modureview/filter/JwtAuthFilter.java
@@ -32,7 +32,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
       "/reviews/*/bookmarks",
       "/search",
       "/users/login",
-      "/favicon.io"
+      "/favicon.io",
+      "/users/**"
   );
 
 

--- a/src/main/java/com/modureview/repository/UserReviewsRepository.java
+++ b/src/main/java/com/modureview/repository/UserReviewsRepository.java
@@ -13,6 +13,28 @@ import com.modureview.entity.Board;
 
 @Repository
 public interface UserReviewsRepository extends JpaRepository<Board, Long> {
+
+
+	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
+		+ "ORDER BY b.createdAt DESC, b.id DESC")
+	Slice<Board> findFirstSliceByAuthorEmailOrderByCreatedAt(
+		@Param("authorEmail") String authorEmail,
+		Pageable pageable
+	);
+
+	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
+		+ "ORDER BY b.bookmarksCount DESC, b.id DESC")
+	Slice<Board> findFirstSliceByAuthorEmailOrderByBookmarksCount(
+		@Param("authorEmail") String authorEmail,
+		Pageable pageable
+	);
+
+	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
+		+ "ORDER BY b.commentsCount DESC, b.id DESC")
+	Slice<Board> findFirstSliceByAuthorEmailOrderByCommentsCount(
+		@Param("authorEmail") String authorEmail,
+		Pageable pageable
+	);
 	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
 		+ "AND (b.createdAt < :createdAt OR "
 		+ " (b.createdAt = :createdAt AND b.id < :boardId)) "
@@ -45,13 +67,6 @@ public interface UserReviewsRepository extends JpaRepository<Board, Long> {
 		@Param("boardId") Long boardId,
 		Pageable pageable
 	);
-
-	Board findTopByAuthorEmailOrderByCreatedAtDesc(String authorEmail);
-
-	Board findTopByAuthorEmailOrderByBookmarksCountDesc(String authorEmail);
-
-	Board findTopByAuthorEmailOrderByCommentsCountDesc(String authorEmail);
-
 	long countByAuthorEmail(String authorEmail);
 
 }

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -35,7 +35,6 @@ public class UserReviewsService {
 		Board targetBoard;
 
 		if (cursorId == null || cursorId == 0L) {
-			// 초기 로딩: 해당 사용자의 최신/최다 게시글 찾기
 			switch (sort) {
 				case "recent":
 					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
@@ -49,8 +48,6 @@ public class UserReviewsService {
 				default:
 					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
 			}
-			
-			// 사용자의 게시글이 없는 경우 빈 Slice 반환
 			if (targetBoard == null) {
 				return new SliceImpl<>(new ArrayList<>(), pageable, false);
 			}

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -32,44 +32,36 @@ public class UserReviewsService {
 		log.info("cursorId == {}", cursorId);
 		log.info("sort == {}", sort);
 
-		Board targetBoard;
-
 		if (cursorId == null || cursorId == 0L) {
 			switch (sort) {
 				case "recent":
-					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
-					break;
+					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCreatedAt(nickname, pageable);
 				case "hotbookmarks":
-					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByBookmarksCountDesc(nickname);
-					break;
+					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByBookmarksCount(nickname, pageable);
 				case "hotcomments":
-					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCommentsCountDesc(nickname);
-					break;
+					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCommentsCount(nickname, pageable);
 				default:
-					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
+					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCreatedAt(nickname, pageable);
 			}
-			if (targetBoard == null) {
-				return new SliceImpl<>(new ArrayList<>(), pageable, false);
-			}
-			
-		} else {
-			targetBoard = boardRepository.findById(cursorId)
-				.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
 		}
+
+		Board targetBoard = boardRepository.findById(cursorId)
+			.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
+
 		switch (sort) {
 			case "recent":
-				return userReviewsRepository.findByAuthorEmailByCreatedAt(nickname, targetBoard.getCreatedAt(),
-					targetBoard.getId(), pageable);
+				return userReviewsRepository.findByAuthorEmailByCreatedAt(
+						nickname, targetBoard.getCreatedAt(), targetBoard.getId(), pageable);
 			case "hotbookmarks":
-				return userReviewsRepository.findByAuthorEmailByBookmarksCount(nickname,
-					targetBoard.getBookmarksCount(), targetBoard.getId(), pageable);
+				return userReviewsRepository.findByAuthorEmailByBookmarksCount(
+						nickname, targetBoard.getBookmarksCount(), targetBoard.getId(), pageable);
 			case "hotcomments":
-				return userReviewsRepository.findByAuthorEmailByCommentsCount(nickname,
-					targetBoard.getCommentsCount(), targetBoard.getId(), pageable);
-
+				return userReviewsRepository.findByAuthorEmailByCommentsCount(
+						nickname, targetBoard.getCommentsCount(), targetBoard.getId(), pageable);
+			default:
+				return userReviewsRepository.findByAuthorEmailByCreatedAt(
+						nickname, targetBoard.getCreatedAt(), targetBoard.getId(), pageable);
 		}
-		return userReviewsRepository.findByAuthorEmailByCreatedAt(nickname, targetBoard.getCreatedAt(),
-			targetBoard.getId(), pageable);
 	}
 
 	public long countByAuthorEmail(String authorEmail) {

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -26,22 +26,22 @@ public class UserReviewsService {
 	private final UserReviewsRepository userReviewsRepository;
 	private final BoardRepository boardRepository;
 
-	public Slice<Board> userReviews(String nickname, Long cursorId, String sort) {
+	public Slice<Board> userReviews(String email, Long cursorId, String sort) {
 		Pageable pageable = PageRequest.of(0, 6);
-		log.info("nickname == {}", nickname);
+		log.info("nickname == {}", email);
 		log.info("cursorId == {}", cursorId);
 		log.info("sort == {}", sort);
 
 		if (cursorId == null || cursorId == 0L) {
 			switch (sort) {
 				case "recent":
-					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCreatedAt(nickname, pageable);
+					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCreatedAt(email, pageable);
 				case "hotbookmarks":
-					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByBookmarksCount(nickname, pageable);
+					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByBookmarksCount(email, pageable);
 				case "hotcomments":
-					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCommentsCount(nickname, pageable);
+					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCommentsCount(email, pageable);
 				default:
-					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCreatedAt(nickname, pageable);
+					return userReviewsRepository.findFirstSliceByAuthorEmailOrderByCreatedAt(email, pageable);
 			}
 		}
 
@@ -51,16 +51,16 @@ public class UserReviewsService {
 		switch (sort) {
 			case "recent":
 				return userReviewsRepository.findByAuthorEmailByCreatedAt(
-						nickname, targetBoard.getCreatedAt(), targetBoard.getId(), pageable);
+					email, targetBoard.getCreatedAt(), targetBoard.getId(), pageable);
 			case "hotbookmarks":
 				return userReviewsRepository.findByAuthorEmailByBookmarksCount(
-						nickname, targetBoard.getBookmarksCount(), targetBoard.getId(), pageable);
+					email, targetBoard.getBookmarksCount(), targetBoard.getId(), pageable);
 			case "hotcomments":
 				return userReviewsRepository.findByAuthorEmailByCommentsCount(
-						nickname, targetBoard.getCommentsCount(), targetBoard.getId(), pageable);
+					email, targetBoard.getCommentsCount(), targetBoard.getId(), pageable);
 			default:
 				return userReviewsRepository.findByAuthorEmailByCreatedAt(
-						nickname, targetBoard.getCreatedAt(), targetBoard.getId(), pageable);
+					email, targetBoard.getCreatedAt(), targetBoard.getId(), pageable);
 		}
 	}
 

--- a/src/test/java/com/modureview/controller/UserReviewsControllerTest.java
+++ b/src/test/java/com/modureview/controller/UserReviewsControllerTest.java
@@ -93,11 +93,11 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - recent 정렬로 사용자 리뷰 조회 성공")
+  @DisplayName("GET /users/{memberEmail}/reviews - recent 정렬로 사용자 리뷰 조회 성공")
   void getUserReviews_Success_Recent() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/test@example.com")
+            get("/users/test@example.com/reviews")
                 .param("cursor", "0")
                 .param("sort", "recent")
                 .accept(MediaType.APPLICATION_JSON))
@@ -120,13 +120,13 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - hotcomment 정렬로 사용자 리뷰 조회 성공")
+  @DisplayName("GET /users/{memberEmail}/reviews - hotcomments 정렬로 사용자 리뷰 조회 성공")
   void getUserReviews_Success_HotComment() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/test@example.com")
+            get("/users/test@example.com/reviews")
                 .param("cursor", "0")
-                .param("sort", "hotcomment")
+                .param("sort", "hotcomments")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
@@ -148,13 +148,13 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - hotbookmark 정렬로 사용자 리뷰 조회 성공")
+  @DisplayName("GET /users/{memberEmail}/reviews - hotbookmarks 정렬로 사용자 리뷰 조회 성공")
   void getUserReviews_Success_HotBookmark() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/test@example.com")
+            get("/users/test@example.com/reviews")
                 .param("cursor", "0")
-                .param("sort", "hotbookmark")
+                .param("sort", "hotbookmarks")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
@@ -176,11 +176,11 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - 존재하지 않는 사용자 이메일로 조회")
+  @DisplayName("GET /users/{memberEmail}/reviews - 존재하지 않는 사용자 이메일로 조회")
   void getUserReviews_Success_NonExistentUser() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/nonexistent@example.com")
+            get("/users/nonexistent@example.com/reviews")
                 .param("cursor", "0")
                 .param("sort", "recent")
                 .accept(MediaType.APPLICATION_JSON))
@@ -204,14 +204,14 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - 커서 기반 페이징 테스트")
+  @DisplayName("GET /users/{memberEmail}/reviews - 커서 기반 페이징 테스트")
   void getUserReviews_Success_CursorPaging() throws Exception {
     List<Board> savedBoards = userReviewsRepository.findAll();
     Long existingBoardId = savedBoards.get(2).getId();
     
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/test@example.com")
+            get("/users/test@example.com/reviews")
                 .param("cursor", existingBoardId.toString())
                 .param("sort", "recent")
                 .accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
## 👀제목  
User Reviews 기능 개선 및 커서 기반 페이징 적용

## 🙋변경 사항  
- `UserReviewsController`  
  - 엔드포인트를 `/users/{memberEmail}/reviews` 로 명확화  
  - 반환 DTO를 `UserReviewsResponse` 로 교체  
  - 총 게시글 수(`totalResults`)를 응답에 포함  
- `CustomSlicePageResponse`  
  - `total_results` 필드 추가  
  - `@Builder` 적용 및 of() 팩토리 메서드 개선  
- `UserReviewsRepository`  
  - 정렬 조건별(Sort: recent, hotbookmarks, hotcomments) 커서 기반 조회 쿼리 추가  
  - 불필요한 Top-조회 메서드 제거, Slice 기반 조회 방식으로 통일  
- `UserReviewsService`  
  - 커서 기반 페이징 처리 로직 단순화  
  - sort 값에 따라 Repository의 Slice 조회 메서드 호출  
- `SecurityConfig`, `JwtAuthFilter`  
  - `/users/**` 경로 permitAll 허용 추가  
- `UserReviewsControllerTest`  
  - 모든 API 호출 경로를 `/users/{memberEmail}/reviews` 기준으로 수정  
  - sort 옵션(`recent`, `hotcomment`, `hotbookmark`)별 조회 테스트 보강  
  - 존재하지 않는 사용자 테스트, 커서 페이징 테스트 포함

## 💎설명  
이번 PR은 **사용자 리뷰(User Reviews) 조회 기능**을 전면 개선하였습니다.  
- 기존의 Top 단일 조회 방식 → Slice 기반 커서 페이징 방식으로 리팩토링  
- 정렬 옵션에 따라 최근순, 북마크 많은 순, 댓글 많은 순 정렬 가능  
- 컨트롤러 응답에서 총 게시글 수(`total_results`)가 함께 반환되어 클라이언트에서 UI 처리 용이  
- 테스트 코드에서는 각 정렬 방식, 커서 페이징, 존재하지 않는 사용자 케이스를 검증하여 안정성 확보  

## 🔨테스트 방법  
- H2 인메모리 DB 기반 `UserReviewsControllerTest` 실행  
- 주요 시나리오 검증:  
  1. `/users/{memberEmail}/reviews?sort=recent` 정상 조회  
  2. `/users/{memberEmail}/reviews?sort=hotcomment` 정상 조회  
  3. `/users/{memberEmail}/reviews?sort=hotbookmark` 정상 조회  
  4. 존재하지 않는 사용자 이메일 요청 시 결과 검증  
  5. 커서 기반 페이징 동작 확인 (기존 게시글 ID 전달 후 다음 페이지 조회)

## ⚙성능  
- **Slice 기반 커서 페이징**으로 불필요한 전체 카운트 쿼리 최소화  
- 정렬 조건별 인덱스 활용 (createdAt, bookmarksCount, commentsCount)  
- 응답 필드에서 총 게시글 수 제공하여 클라이언트 단 추가 요청 방지

## ℹ추가 정보  
- 기존 `SliceBoardResponse` 제거 → `UserReviewsResponse` 로 일원화  
- 추후 서비스 성능 최적화를 위해 QueryDSL 혹은 Native Query 전환 고려 가능  

## ❌이슈  
- 정렬 옵션 입력값 유효성 검증 미비 (추후 Enum 기반 검증 추가 필요)  
- `/users/**` permitAll 처리로 인한 인증/인가 보강 필요