### PR TITLE
Feat/user nickname

### DIFF
--- a/src/main/java/com/modureview/controller/SearchController.java
+++ b/src/main/java/com/modureview/controller/SearchController.java
@@ -1,8 +1,8 @@
 package com.modureview.controller;
 
-import com.modureview.dto.response.BoardSearchResponse;
 import com.modureview.dto.response.CustomPageResponse;
 import com.modureview.dto.response.CustomSlicePageResponse;
+import com.modureview.dto.response.SliceBoardResponse;
 import com.modureview.entity.Board;
 import com.modureview.entity.Category;
 import com.modureview.service.SearchService;
@@ -28,7 +28,7 @@ public class SearchController {
 
 
   @GetMapping("/search")
-  public ResponseEntity<CustomPageResponse<BoardSearchResponse>> getBoardSearch(
+  public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getBoardSearch(
       @RequestParam(name = "keyword") String keyword,
       @RequestParam(name = "page", defaultValue = "0") int page,
       @RequestParam(name = "sort", defaultValue = "recent") String sort
@@ -36,10 +36,10 @@ public class SearchController {
     String decodeKeyword = URLDecoder.decode(keyword, "UTF-8");
     log.info("Searching for " + decodeKeyword);
     Page<Board> boardPage = searchService.boardSearch(decodeKeyword, page, sort);
-    List<BoardSearchResponse> listSearchBoard = boardPage.getContent().stream()
-        .map(BoardSearchResponse::fromEntity)
+    List<SliceBoardResponse> listSearchBoard = boardPage.getContent().stream()
+        .map(SliceBoardResponse::fromEntity)
         .toList();
-    CustomPageResponse<BoardSearchResponse> SearchPage = new CustomPageResponse<>(
+    CustomPageResponse<SliceBoardResponse> SearchPage = new CustomPageResponse<>(
         listSearchBoard,
         boardPage.getNumber() + 1,
         boardPage.getTotalPages()
@@ -50,13 +50,13 @@ public class SearchController {
 
 
   @GetMapping("/reviews")
-  public ResponseEntity<CustomSlicePageResponse<BoardSearchResponse>> getBoardsByCategory(
+  public ResponseEntity<CustomSlicePageResponse<SliceBoardResponse>> getBoardsByCategory(
       @RequestParam(name = "categoryId") Category category,
       @RequestParam(name = "cursor", defaultValue = "0") Long cursorId,
       @RequestParam(name = "sort", defaultValue = "recent") String sort) {
     Slice<Board> boardSlice = searchService.getCategoryBoard(category, cursorId, sort);
-    List<BoardSearchResponse> dtoList = boardSlice.getContent().stream()
-        .map(BoardSearchResponse::fromEntity)
+    List<SliceBoardResponse> dtoList = boardSlice.getContent().stream()
+        .map(SliceBoardResponse::fromEntity)
         .collect(Collectors.toList());
 
     Long nextCursorValue = null;
@@ -65,13 +65,10 @@ public class SearchController {
       nextCursorValue = lastBoardInSlice.getId();
     }
 
-    CustomSlicePageResponse<BoardSearchResponse> customResponse = new CustomSlicePageResponse<>(
+    CustomSlicePageResponse<SliceBoardResponse> customResponse = CustomSlicePageResponse.of(
         dtoList,
         nextCursorValue,
-        boardSlice.hasNext(),
-        boardSlice.getNumberOfElements(),
-        boardSlice.getSize(),
-        boardSlice.isFirst()
+        boardSlice.hasNext()
     );
 
     return ResponseEntity.ok(customResponse);

--- a/src/main/java/com/modureview/dto/response/CustomSlicePageResponse.java
+++ b/src/main/java/com/modureview/dto/response/CustomSlicePageResponse.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @Builder
 
-public class CustomSlicePageResponse<T> {
+public class CustomSlicePageResponse<T>  {
+
 
   private final List<T> results;
   private final Long next_cursor;

--- a/src/main/java/com/modureview/service/JwtTokenService.java
+++ b/src/main/java/com/modureview/service/JwtTokenService.java
@@ -35,12 +35,12 @@ public class JwtTokenService {
   private final Long accessTokenExpire = 60 * 60L;
   private final Long refreshTokenExpire = 30 * 24 * 60 * 60L;
 
-  public List<ResponseCookie> loginTokenIssue(String userEmail) {
+  public List<ResponseCookie> loginTokenIssue(String userEmail,String nickname) {
     return List.of(
         createAccessToken(userEmail),
         createRefreshToken(userEmail),
         createUserEmailCookie(userEmail),
-        createUserNickName(userEmail)
+        createUserNickname(nickname)
     );
   }
 
@@ -58,8 +58,8 @@ public class JwtTokenService {
     return createCookie("userEmail", userEmail, refreshTokenExpire, true);
   }
 
-  public ResponseCookie createUserNickName(String userEmail){
-    return createCookie("userNickName", userEmail, refreshTokenExpire, true);
+  public ResponseCookie createUserNickname(String nickname){
+    return createCookie("userNickname", nickname , refreshTokenExpire, true);
   }
 
   public void validateToken(String token) {

--- a/src/main/java/com/modureview/service/JwtTokenService.java
+++ b/src/main/java/com/modureview/service/JwtTokenService.java
@@ -39,7 +39,8 @@ public class JwtTokenService {
     return List.of(
         createAccessToken(userEmail),
         createRefreshToken(userEmail),
-        createUserEmailCookie(userEmail)
+        createUserEmailCookie(userEmail),
+        createUserNickName(userEmail)
     );
   }
 
@@ -55,6 +56,10 @@ public class JwtTokenService {
 
   public ResponseCookie createUserEmailCookie(String userEmail) {
     return createCookie("userEmail", userEmail, refreshTokenExpire, true);
+  }
+
+  public ResponseCookie createUserNickName(String userEmail){
+    return createCookie("userNickName", userEmail, refreshTokenExpire, true);
   }
 
   public void validateToken(String token) {

--- a/src/test/java/com/modureview/service/JwtTokenServiceLoginIssueTest.java
+++ b/src/test/java/com/modureview/service/JwtTokenServiceLoginIssueTest.java
@@ -1,0 +1,62 @@
+package com.modureview.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+class JwtTokenServiceLoginIssueTest {
+
+  static class StubJwtTokenService extends JwtTokenService {
+    @Override
+    public ResponseCookie createAccessToken(String userEmail) {
+      return ResponseCookie.from("accessToken", "stub-access")
+          .httpOnly(true)
+          .secure(true)
+          .sameSite("LAX")
+          .path("/")
+          .maxAge(60 * 60L)
+          .domain(".modu-review.com")
+          .build();
+    }
+
+    @Override
+    public ResponseCookie createRefreshToken(String userEmail) {
+      return ResponseCookie.from("refreshToken", "stub-refresh")
+          .httpOnly(true)
+          .secure(true)
+          .sameSite("LAX")
+          .path("/")
+          .maxAge(30 * 24 * 60 * 60L)
+          .domain(".modu-review.com")
+          .build();
+    }
+  }
+
+  @Test
+  @DisplayName("loginTokenIssue는 4개 쿠키를 발급한다")
+  void loginTokenIssue_returns_four_cookies() {
+    String email = "user@domain.com";
+    JwtTokenService service = new StubJwtTokenService();
+
+    List<ResponseCookie> cookies = service.loginTokenIssue(email);
+
+    assertThat(cookies).hasSize(4);
+    assertThat(cookies.stream().map(ResponseCookie::getName).toList())
+        .containsExactlyInAnyOrder("accessToken", "refreshToken", "userEmail", "userNickName");
+
+    Map<String, ResponseCookie> byName = cookies.stream()
+        .collect(Collectors.toMap(ResponseCookie::getName, c -> c));
+
+    assertThat(byName.get("userEmail").getValue()).isEqualTo(email);
+    assertThat(byName.get("userEmail").isHttpOnly()).isTrue();
+
+    assertThat(byName.get("userNickName").getValue()).isEqualTo(email);
+    assertThat(byName.get("userNickName").isHttpOnly()).isTrue();
+  }
+}
+

--- a/src/test/java/com/modureview/service/JwtTokenServiceLoginIssueTest.java
+++ b/src/test/java/com/modureview/service/JwtTokenServiceLoginIssueTest.java
@@ -41,9 +41,10 @@ class JwtTokenServiceLoginIssueTest {
   @DisplayName("loginTokenIssue는 4개 쿠키를 발급한다")
   void loginTokenIssue_returns_four_cookies() {
     String email = "user@domain.com";
+    String nickname = "nickname123";
     JwtTokenService service = new StubJwtTokenService();
 
-    List<ResponseCookie> cookies = service.loginTokenIssue(email);
+    List<ResponseCookie> cookies = service.loginTokenIssue(email, nickname);
 
     assertThat(cookies).hasSize(4);
     assertThat(cookies.stream().map(ResponseCookie::getName).toList())
@@ -55,8 +56,7 @@ class JwtTokenServiceLoginIssueTest {
     assertThat(byName.get("userEmail").getValue()).isEqualTo(email);
     assertThat(byName.get("userEmail").isHttpOnly()).isTrue();
 
-    assertThat(byName.get("userNickName").getValue()).isEqualTo(email);
+    assertThat(byName.get("userNickName").getValue()).isEqualTo(nickname);
     assertThat(byName.get("userNickName").isHttpOnly()).isTrue();
   }
 }
-

--- a/src/test/java/com/modureview/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/modureview/service/JwtTokenServiceTest.java
@@ -47,10 +47,13 @@ class JwtTokenServiceTest {
   @Test
   @DisplayName("지정한 토큰이 잘 지정되는지 확인 ")
   void loginTokenIssueCheck() {
-    List<ResponseCookie> cookies = jwtTokenService.loginTokenIssue("user@domain.com");
+    String email = "user@domain.com";
+    String nickname = "nickname123";
 
-    assertThat(cookies).hasSize(3);
+    List<ResponseCookie> cookies = jwtTokenService.loginTokenIssue(email, nickname);
+
+    assertThat(cookies).hasSize(4);
     assertThat(cookies.stream().map(ResponseCookie::getName).toList())
-        .containsExactlyInAnyOrder("accessToken", "refreshToken", "userEmail");
+        .containsExactlyInAnyOrder("accessToken", "refreshToken", "userEmail", "userNickName");
   }
 }


### PR DESCRIPTION
## 👀제목  
JwtTokenService 개선: userNickname 쿠키 발급 및 SearchController 리팩토링

## 🙋변경 사항  
- **JwtTokenService**  
  - `loginTokenIssue` 메서드가 `userNickname` 쿠키를 추가 발급하도록 변경  
  - `createUserNickname(String nickname)` 메서드 추가  
- **SearchController**  
  - `SliceBoardResponse` → `BoardSearchResponse` 로 DTO 통일  
  - `/search`, `/reviews` API 응답 타입 개선 (`CustomPageResponse`, `CustomSlicePageResponse` 사용)  
- **CustomSlicePageResponse**  
  - @Builder 적용 (리팩토링 일환)  
- **테스트 코드**  
  - `JwtTokenServiceLoginIssueTest` 신규 추가 → 4개 쿠키(`accessToken`, `refreshToken`, `userEmail`, `userNickname`) 발급 검증  
  - 기존 `JwtTokenServiceTest` 수정 → 4개 쿠키를 검증하도록 업데이트

## 💎설명  
이번 PR은 로그인 시 발급되는 쿠키 구조 개선과 검색 관련 컨트롤러 리팩토링을 포함합니다.  
- 로그인 성공 시 사용자 이메일뿐 아니라 **닉네임(userNickname)** 쿠키도 함께 발급되도록 확장했습니다.  
- 이 변경으로 프론트엔드에서 닉네임을 별도 API 요청 없이 쿠키로 활용할 수 있어 편의성이 향상됩니다.  
- `SearchController`는 더 이상 `SliceBoardResponse`를 사용하지 않고, **BoardSearchResponse** DTO로 일원화하여 응답 일관성을 확보했습니다.  
- 통합 테스트에서 쿠키 개수 및 값 검증을 강화하여 안정성을 보장했습니다.

## 🔨테스트 방법  
- `JwtTokenServiceLoginIssueTest` 실행 → `loginTokenIssue`가 4개 쿠키를 발급하는지 확인  
  1. accessToken, refreshToken, userEmail, userNickname 쿠키 존재 여부  
  2. userEmail / userNickname 값 일치 여부 검증  
  3. HttpOnly, Secure, SameSite 옵션 확인  
- `JwtTokenServiceTest` 실행 → 기존 3개 → 4개 쿠키 발급 확인  
- `/search`, `/reviews` API 호출 시 응답 DTO 타입이 정상적으로 매핑되는지 확인  

## ⚙성능  
- 성능에 직접적인 영향은 없음  
- 쿠키 추가 발급에 따른 오버헤드는 무시할 수준  
- SearchController 응답 DTO 단순화로 직관적인 데이터 처리 가능  

## ℹ추가 정보  
- Cookie의 `domain`, `path`, `sameSite` 설정은 기존과 동일하게 유지  
- 추후 사용자 프로필 관련 확장 시 `userNickname` 쿠키 기반 접근이 가능  

## ❌이슈  
- 현재 `userNickname` 쿠키는 별도 암호화 없이 평문 저장 → 민감 정보 노출 위험 가능성 있음  
- JWT payload 활용 및 암호화된 claim 기반의 nickname 제공을 고려할 필요 있음