### PR TITLE
refactor < email -> nickname > :: Controller 를 중심으로 리팩토링 진행하고있습니다.

### DIFF
--- a/src/main/java/com/modureview/controller/MyPageController.java
+++ b/src/main/java/com/modureview/controller/MyPageController.java
@@ -26,10 +26,11 @@ public class MyPageController {
 
 	@GetMapping("/users/me/reviews")
 	public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getUserBoards(
-		@CookieValue(name = "userEmail") String email,
+		@CookieValue(name = "userNickname") String nickname,
 		@RequestParam(name = "page", defaultValue = "0") int page
 	) {
-		Page<Board> boardPage = myPageService.myPageBoard(email, page);
+
+		Page<Board> boardPage = myPageService.myPageBoard(nickname, page);
 		List<SliceBoardResponse> listMyPage = boardPage.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.toList();
@@ -43,10 +44,10 @@ public class MyPageController {
 
 	@GetMapping("/users/me/bookmarks")
 	public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getBookMarkBoards(
-		@CookieValue(name = "userEmail") String email,
+		@CookieValue(name = "userNickname") String nickname,
 		@RequestParam(name = "page", defaultValue = "0") int page
 	) {
-		Page<Board> boardMyPage = myPageService.myPageBookmark(email, page);
+		Page<Board> boardMyPage = myPageService.myPageBookmark(nickname, page);
 		List<SliceBoardResponse> listMyPage = boardMyPage.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.toList();

--- a/src/main/java/com/modureview/dto/response/SliceBoardResponse.java
+++ b/src/main/java/com/modureview/dto/response/SliceBoardResponse.java
@@ -10,8 +10,7 @@ import lombok.Builder;
 public record SliceBoardResponse(
     Long board_id,
     String title,
-    String author_id,
-    String author_email,
+    String author_nickname,
     Category category,
     String preview,
     Integer comments_count,
@@ -29,8 +28,7 @@ public record SliceBoardResponse(
         .board_id(board.getId())
         .title(board.getTitle())
         .category(board.getCategory())
-        .author_id(board.getAuthorEmail().split("@")[0])
-        .author_email(board.getAuthorEmail())
+        .author_nickname(board.getNickname())
         .created_at(board.getCreatedAt())
         .preview(board.getPreview())
         .comments_count(board.getCommentsCount())

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -47,8 +47,8 @@ public class Board {
   @JsonBackReference
   private User user;
 
-  @Column(name="author_email")
-  private String authorEmail;
+  @Column(name = "nickname")
+  private String nickname;
 
   @Enumerated(EnumType.STRING)
   private Category category;
@@ -99,10 +99,10 @@ public class Board {
   }
 
   @Builder
-  public Board(String title, String authorEmail, Category category, String content,
-      Integer commentsCount, Integer bookmarksCount) {
+  public Board(String title, Category category, String content,
+      Integer commentsCount, Integer bookmarksCount , String nickname) {
     this.title = title;
-    this.authorEmail = authorEmail;
+    this.nickname = nickname;
     this.category = category;
     this.content = content;
     this.commentsCount = commentsCount;

--- a/src/main/java/com/modureview/entity/BookMark.java
+++ b/src/main/java/com/modureview/entity/BookMark.java
@@ -25,6 +25,8 @@ public class BookMark {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  private String nickname;
+
   private String email;
 
   private Long userId;

--- a/src/main/java/com/modureview/repository/MyPageBookMarkRepository.java
+++ b/src/main/java/com/modureview/repository/MyPageBookMarkRepository.java
@@ -13,9 +13,9 @@ public interface MyPageBookMarkRepository extends JpaRepository<BookMark, Long> 
   @Query(
       value = "SELECT bm.boardId "
           + "FROM BookMark bm "
-          + "WHERE bm.email = :email"
+          + "WHERE bm.nickname = :nickname"
   )
-  Page<Long> findBookMarksByEmail(String email, Pageable pageable);
+  Page<Long> findBookMarksByNickname(String nickname, Pageable pageable);
 
 
 }

--- a/src/main/java/com/modureview/repository/MyPageRepository.java
+++ b/src/main/java/com/modureview/repository/MyPageRepository.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MyPageRepository extends JpaRepository<Board, Long> {
 
-  @Query(value = "SELECT b FROM Board b WHERE b.authorEmail = :email")
-  Page<Board> findBoardByAuthorEmail(@Param("email") String email, Pageable pageable);
+  @Query(value = "SELECT b FROM Board b WHERE b.nickname = :nickname")
+  Page<Board> findBoardByNickname(@Param("nickname") String nickname, Pageable pageable);
+
+
 
 }

--- a/src/main/java/com/modureview/repository/UserRepository.java
+++ b/src/main/java/com/modureview/repository/UserRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
+
+  Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/modureview/service/MyPageService.java
+++ b/src/main/java/com/modureview/service/MyPageService.java
@@ -22,6 +22,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
+
+//email -> 완료
 @Slf4j
 @Service
 @Transactional
@@ -32,24 +34,24 @@ public class MyPageService {
   private final MyPageRepository myPageRepository;
   private final MyPageBookMarkRepository myPageBookMarkRepository;
 
-  public Page<Board> myPageBoard(String email, int page) {
+  public Page<Board> myPageBoard(String nickname, int page) {
     Sort sortCriteria = Sort.by(Direction.DESC, "createdAt");
     Pageable pageable = PageRequest.of(page - 1, 6, sortCriteria);
 
-    if (userRepository.findByEmail(email).isPresent()) {
-      return myPageRepository.findBoardByAuthorEmail(email, pageable);
+    if (userRepository.findByNickname(nickname).isPresent()) {
+      return myPageRepository.findBoardByNickname(nickname, pageable);
     }
     throw new CustomException(UserErrorCode.USER_NOT_FOUND);
   }
 
-  public Page<Board> myPageBookmark(String email, int page) {
+  public Page<Board> myPageBookmark(String nickname, int page) {
     Sort sortCriteria = Sort.by(Direction.DESC, "createdAt");
     Pageable pageable = PageRequest.of(page - 1, 6, sortCriteria);
-    if (userRepository.findByEmail(email).isEmpty()) {
+    if (userRepository.findByNickname(nickname).isEmpty()) {
       throw new CustomException(UserErrorCode.USER_NOT_FOUND);
     }
 
-    Page<Long> boardIdPage = myPageBookMarkRepository.findBookMarksByEmail(email, pageable);
+    Page<Long> boardIdPage = myPageBookMarkRepository.findBookMarksByNickname(nickname, pageable);
     List<Long> boardIds = boardIdPage.getContent();
     List<Board> boardList = myPageRepository.findAllById(boardIds);
     Map<Long, Board> boardMap = boardList.stream()
@@ -59,9 +61,5 @@ public class MyPageService {
         .filter(Objects::nonNull)
         .toList();
     return new PageImpl<>(sortedBoards, pageable, boardIdPage.getTotalElements());
-
-
   }
-
-
 }

--- a/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
+++ b/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
@@ -75,7 +75,7 @@ class MyPageServiceUnitTest {
     Pageable pageable = PageRequest.of(pageNumber - 1, pageSize,
         Sort.by(Sort.Direction.DESC, "createdAt"));
     Page<Long> idPage = new PageImpl<>(bookmarkIds, pageable, bookmarkIds.size());
-    when(myPageBookMarkRepository.findBookMarksByEmail(email, pageable))
+    when(myPageBookMarkRepository.findBookMarksByNickname(email, pageable))
         .thenReturn(idPage);
 
     Board b1 = Board.builder()


### PR DESCRIPTION
## 👀제목  
마이페이지 리팩토링: 이메일 → 닉네임 기반으로 전환 (`refactor/MyPage`)

## 🙋변경 사항  
- **Controller**
  - `/users/me/reviews`, `/users/me/bookmarks` 요청 시 쿠키 키를 `userEmail` → `userNickname`으로 변경.
  - 서비스 호출도 이메일 대신 닉네임을 인자로 전달하도록 수정.
- **Service (`MyPageService`)**
  - `myPageBoard(String email, int page)` → `myPageBoard(String nickname, int page)`
  - `myPageBookmark(String email, int page)` → `myPageBookmark(String nickname, int page)`
  - 사용자 존재 검증 로직을 `findByEmail` → `findByNickname`으로 대체.
  - 북마크 조회 시 `findBookMarksByEmail` → `findBookMarksByNickname` 사용.
- **Repository**
  - `MyPageRepository`: 작성자 기준 조회 쿼리를 `authorEmail` → `nickname` 컬럼 기준으로 변경.
  - `MyPageBookMarkRepository`: 파라미터 `email` → `nickname`으로 변경하고 쿼리 수정.
  - `UserRepository`: `findByNickname(String nickname)` 메서드 추가.
- **Entity / DTO**
  - `Board`: `author_email` 필드를 제거하고 `nickname` 컬럼으로 대체.
  - `SliceBoardResponse`: `author_id`/`author_email` → `author_nickname`으로 통일. 매핑 로직도 `board.getNickname()` 사용.
- **Test**
  - `MyPageServiceUnitTest`: 저장소 호출 목킹을 닉네임 기반 메서드로 교체.

## 💎설명  
- 로그인/세션 전반이 **닉네임 쿠키(`userNickname`)** 기반으로 운영되는 변경 사항에 맞춰 **마이페이지 전 구간을 이메일 → 닉네임**으로 전환했습니다.
- Controller에서 쿠키 참조 키만 바뀐 것이 아니라, **엔터티/레포지토리/서비스 전반의 식별자 기준**도 함께 일관화했습니다.
- DTO도 닉네임을 1급 시민으로 다루도록 정리하여, 프론트엔드에서 별도 파싱 없이 바로 렌더링 가능합니다.

## 🔨테스트 방법  
1. 브라우저/테스트 클라이언트에 `userNickname` 쿠키를 설정 후 호출합니다.
   - `GET /users/me/reviews?page=1`
   - `GET /users/me/bookmarks?page=1`
2. 응답 바디의 `results[*].author_nickname` 필드가 기대한 닉네임으로 노출되는지 확인합니다.
3. 존재하지 않는 닉네임의 경우 `USER_NOT_FOUND` 예외가 발생하는지 확인합니다.
4. 단위 테스트(`MyPageServiceUnitTest`)를 실행해 닉네임 기반 저장소 메서드가 호출되는지 검증합니다.

## ⚙성능  
- 기능/쿼리 로직 자체는 동일하며, **식별자 필드 교체**만 수행되어 성능 영향은 없습니다.
- 북마크/게시글 조회 시 기존 인덱스 전략과 페이지네이션 정책을 유지합니다.

## ℹ추가 정보  
- 이전 PR(`feat/userNickname`)에서 로그인 시 `userNickname` 쿠키가 발급되도록 변경된 사전 작업과 호환됩니다.
- 프론트엔드는 이메일 파싱 없이 닉네임을 직접 사용 가능: 프로필/마이페이지 링크 생성 단순화.

## ❌이슈  
- DB 스키마에서 `Board.author_email` → `Board.nickname` 변경에 따른 **데이터 마이그레이션** 필요(기존 데이터의 닉네임 채움 전략 합의 필요).
- `BookMark` 엔티티에 `nickname` 필드가 추가되었으므로, 생성/삭제 시 일관성 검증이 필요합니다.
