### PR TITLE
refactor < email -> nickname > :: Bookmark에 대한 리팩토링입니다.

### DIFF
--- a/src/main/java/com/modureview/controller/BookmarkController.java
+++ b/src/main/java/com/modureview/controller/BookmarkController.java
@@ -29,32 +29,35 @@ public class BookmarkController {
   @GetMapping("/reviews/{reviewId}/bookmarks")
   public ResponseEntity<BookmarkDetailResponse> getBookMarkDetail(
       @PathVariable Long reviewId,
-      @CookieValue(name = "userEmail", required = false, defaultValue = "null") String email) {
-    BookmarkDetailResponse bookMarkDetailResponse = bookmarkService.bookmarkDetail(reviewId, email);
+      @CookieValue(name = "userNickname" , required = false , defaultValue = "null") String nickname) {
+    BookmarkDetailResponse bookMarkDetailResponse = bookmarkService.bookmarkDetail(reviewId, nickname);
     return ResponseEntity.ok(bookMarkDetailResponse);
 
   }
 
   @PostMapping("reviews/{reviewId}/bookmarks")
   public ResponseEntity<?> addBookmark(@PathVariable Long reviewId,
-     @RequestBody BookmarkRequest bookmarkRequest) {
+     //@RequestBody BookmarkRequest bookmarkRequest,
+      @CookieValue (name = "userNickname" , required = true , defaultValue = "null")String nickname) {
     log.info("reviewId == {}", reviewId);
-    log.info("bookmarkRequest == {}", bookmarkRequest);
-    String userEmail = bookmarkRequest.userEmail();
+
+    log.info("nickname == {}", nickname);
+    //String userEmail = bookmarkRequest.userEmail();
     boardService.findBoard(reviewId);
-    Long userId = userService.findUserId(userEmail);
-    bookmarkService.saveBookmark(reviewId, userId, userEmail);
+    //Long userId = userService.findUserId(userEmail);
+    Long userId = userService.findUserIdByNickname(nickname);
+    bookmarkService.saveBookmark(reviewId, userId, nickname);
 
     return new ResponseEntity<>(HttpStatus.CREATED);
   }
 
   @DeleteMapping("reviews/{reviewId}/bookmarks")
   public ResponseEntity<?> deleteBookmark(@PathVariable Long reviewId,
-     @RequestBody BookmarkRequest bookmarkRequest) {
+     //@RequestBody BookmarkRequest bookmarkRequest
+      @CookieValue(name = "userNickname" , required = false ,defaultValue = "null") String nickname) {
     log.info("reviewId == {}", reviewId);
-    log.info("bookmarkRequest == {}", bookmarkRequest);
-    String userEmail = bookmarkRequest.userEmail();
-    bookmarkService.deleteBookmark(reviewId, userEmail);
+    log.info("nickname == {}", nickname);
+    bookmarkService.deleteBookmark(reviewId, nickname);
 
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/src/main/java/com/modureview/repository/BookmarkRepository.java
+++ b/src/main/java/com/modureview/repository/BookmarkRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<BookMark, Long> {
 
-  Optional<BookMark> findByEmailAndBoardId(String userEmail, Long boardId);
 
-  Boolean existsByBoardIdAndEmail(Long boardId, String email);
+  Optional<BookMark> findByNicknameAndBoardId(String nickname, Long boardId);
+
+  Boolean existsByNicknameAndBoardId(String nickname, Long boardId);
 
 }

--- a/src/main/java/com/modureview/service/BookmarkService.java
+++ b/src/main/java/com/modureview/service/BookmarkService.java
@@ -30,11 +30,11 @@ public class BookmarkService {
   private final StringRedisTemplate stringRedisTemplate;
 
   @Transactional
-  public void saveBookmark(Long boardId, Long userId, String email) {
+  public void saveBookmark(Long boardId, Long userId, String nickname) {
     BookMark bookmark = BookMark.builder()
         .boardId(boardId)
         .userId(userId)
-        .email(email)
+        .nickname(nickname)
         .build();
 
     bookmarkRepository.save(bookmark);
@@ -46,8 +46,8 @@ public class BookmarkService {
   }
 
   @Transactional
-  public void deleteBookmark(Long boardId, String email) {
-    BookMark bookmarks = bookmarkRepository.findByEmailAndBoardId(email, boardId)
+  public void deleteBookmark(Long boardId, String nickname) {
+    BookMark bookmarks = bookmarkRepository.findByNicknameAndBoardId(nickname, boardId)
         .orElseThrow(() -> new BookmarkNotExistException(BookmarkErrorCode.BOOKMARK_NOT_FOUND));
     bookmarkRepository.delete(bookmarks);
 
@@ -57,18 +57,18 @@ public class BookmarkService {
     });
   }
 
-  public BookmarkDetailResponse bookmarkDetail(Long reviewId, String email) {
+  public BookmarkDetailResponse bookmarkDetail(Long reviewId, String nickname) {
     log.info("reviewId == {}", reviewId);
-    log.info("email    == {}", email);
+    log.info("email    == {}", nickname);
 
     Board targetBoard = boardRepository.findById(reviewId)
         .orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
     
-    if (!"null".equals(email)) {
-      userRepository.findByEmail(email)
+    if (!"null".equals(nickname)) {
+      userRepository.findByNickname(nickname)
           .orElseThrow(() -> new CustomException(JwtErrorCode.FORBIDDEN));
 
-      boolean hasBookmark = bookmarkRepository.existsByBoardIdAndEmail(reviewId, email);
+      boolean hasBookmark = bookmarkRepository.existsByNicknameAndBoardId(nickname, reviewId);
       return BookmarkDetailResponse.fromEntity(
           hasBookmark,
           targetBoard.getBookmarksCount()


### PR DESCRIPTION
## 👀제목  
북마크 리팩토링: 이메일 → 닉네임 기반 전환 (`refactor/Bookmark`)

## 🙋변경 사항  
- **Controller (`BookmarkController`)**
  - GET `/reviews/{reviewId}/bookmarks`: `@CookieValue`를 `userEmail` → `userNickname`으로 전환.
  - POST `/reviews/{reviewId}/bookmarks`: RequestBody 기반 userEmail 전달 제거 → `userNickname` 쿠키 사용.
  - DELETE `/reviews/{reviewId}/bookmarks`: RequestBody 제거, `userNickname` 쿠키 사용.
- **Service (`BookmarkService`)**
  - `saveBookmark(Long boardId, Long userId, String email)` → `saveBookmark(Long boardId, Long userId, String nickname)`.
  - `deleteBookmark(Long boardId, String email)` → `deleteBookmark(Long boardId, String nickname)`.
  - `bookmarkDetail(Long reviewId, String email)` → `bookmarkDetail(Long reviewId, String nickname)`.
  - 내부 로직 전반을 이메일 기준 → 닉네임 기준으로 수정.
- **Repository (`BookmarkRepository`)**
  - `findByEmailAndBoardId` → `findByNicknameAndBoardId`.
  - `existsByBoardIdAndEmail` → `existsByNicknameAndBoardId`.
  - 쿼리 및 반환 타입 모두 닉네임 기준으로 변경.

## 💎설명  
- 북마크 기능 전반을 **닉네임 중심으로 식별**하도록 리팩토링했습니다.
- 컨트롤러 레벨에서 RequestBody로 userEmail을 전달받던 부분을 제거하고, 세션 쿠키(`userNickname`) 기반으로 처리하도록 단순화했습니다.
- Service와 Repository도 전부 닉네임 기반으로 수정하여, DB 엔티티(`BookMark`) 저장 시 `nickname` 필드를 활용합니다.
- 결과적으로 로그인/세션의 주 식별자가 이메일에서 닉네임으로 변경된 흐름과 일관성을 맞췄습니다.

## 🔨테스트 방법  
1. 브라우저/테스트 클라이언트에 `userNickname` 쿠키를 설정.
2. `POST /reviews/{reviewId}/bookmarks` 요청 → 정상적으로 북마크 생성되는지 확인.
3. `GET /reviews/{reviewId}/bookmarks` 요청 → 응답에 닉네임 기반 북마크 상태와 카운트 확인.
4. `DELETE /reviews/{reviewId}/bookmarks` 요청 → 북마크 삭제 성공 여부 확인.

## ⚙성능  
- 기능적 로직 동일, 단순 식별자 변경만 수행.
- Repository 인덱스/쿼리 구조가 단순해 성능 영향 없음.
- Controller에서 RequestBody 제거 → 요청 구조 간결화.

## ℹ추가 정보  
- 이전 `refactor/MyPage`, `feat/userNickname` PR에서 진행된 닉네임 전환 흐름과 연계됩니다.
- 프론트엔드도 쿠키(`userNickname`)만으로 북마크 요청 가능.

## ❌이슈  
- DB에 `BookMark.nickname` 필드가 추가되었으므로, 데이터 마이그레이션 필요.
- 기존 이메일 기반 북마크 데이터 처리 전략 수립 필요 (닉네임 매핑 정책).