### PR TITLE
refactor < MyPage > :: MyPage 관한 리팩토링입니다.

### DIFF
--- a/src/main/java/com/modureview/controller/MyPageController.java
+++ b/src/main/java/com/modureview/controller/MyPageController.java
@@ -1,5 +1,7 @@
 package com.modureview.controller;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -30,7 +32,8 @@ public class MyPageController {
 		@RequestParam(name = "page", defaultValue = "0") int page
 	) {
 
-		Page<Board> boardPage = myPageService.myPageBoard(nickname, page);
+		String decoded = URLDecoder.decode(nickname, StandardCharsets.UTF_8);
+		Page<Board> boardPage = myPageService.myPageBoard(decoded, page);
 		List<SliceBoardResponse> listMyPage = boardPage.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.toList();
@@ -47,7 +50,8 @@ public class MyPageController {
 		@CookieValue(name = "userNickname") String nickname,
 		@RequestParam(name = "page", defaultValue = "0") int page
 	) {
-		Page<Board> boardMyPage = myPageService.myPageBookmark(nickname, page);
+		String decoded = URLDecoder.decode(nickname, StandardCharsets.UTF_8);
+		Page<Board> boardMyPage = myPageService.myPageBookmark(decoded, page);
 		List<SliceBoardResponse> listMyPage = boardMyPage.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.toList();

--- a/src/test/java/com/modureview/controller/MyPageControllerTest.java
+++ b/src/test/java/com/modureview/controller/MyPageControllerTest.java
@@ -44,27 +44,32 @@ class MyPageControllerTest {
   @Autowired
   private UserRepository userRepository;
 
+  private String targetNickname;
+
   @BeforeEach
   void setUp() {
 
     User newUser = userRepository.save(User.builder()
-        .email("작성자")
+        .email("writer@test.com")
+        .nickname("작성자")
         .build());
     User targetUser = userRepository.save(User.builder()
-        .email("test")
+        .email("target@test.com")
+        .nickname("테스트닉")
         .build());
+    targetNickname = targetUser.getNickname();
 
     List<Board> boards = new ArrayList<>();
     for (int i = 0; i < 30; i++) {
       if (i % 2 != 0) {
         boards.add(
-            Board.builder().title("TestTitle" + i).user(newUser).authorEmail(newUser.getEmail())
+            Board.builder().title("TestTitle" + i).user(newUser).nickname(newUser.getNickname())
                 .content("<p>내용 예시 " + i + "</p>")
                 .commentsCount(ThreadLocalRandom.current().nextInt(1, 101))
                 .bookmarksCount(ThreadLocalRandom.current().nextInt(1, 101)).build());
       } else {
         boards.add(
-            Board.builder().user(targetUser).authorEmail(targetUser.getEmail())
+            Board.builder().user(targetUser).nickname(targetUser.getNickname())
                 .content("<p>내용 예시 " + i + "</p>")
                 .commentsCount(ThreadLocalRandom.current().nextInt(1, 101))
                 .bookmarksCount(ThreadLocalRandom.current().nextInt(1, 101)).build());
@@ -84,7 +89,7 @@ class MyPageControllerTest {
     long startTime = System.currentTimeMillis();
     MvcResult mvcResult = mockMvc.perform(
             get("/users/me/reviews")
-                .cookie(new Cookie("userEmail", "test"))
+                .cookie(new Cookie("userNickname", targetNickname))
                 .param("page", "1")
         )
         .andExpect(status().isOk())

--- a/src/test/java/com/modureview/service/MyPageServiceTest.java
+++ b/src/test/java/com/modureview/service/MyPageServiceTest.java
@@ -43,13 +43,15 @@ class MyPageServiceTest {
   @BeforeEach
   void setUp() {
     User newUser = User.builder()
-        .email("TargetEmail")
+        .email("target@example.com")
+        .nickname("target")
         .build();
 
     User user = userRepository.save(newUser);
 
     User notTargetUser = User.builder()
-        .email("NotTargetEmail")
+        .email("notarget@example.com")
+        .nickname("notarget")
         .build();
 
     User NotTargetUser = userRepository.save(notTargetUser);
@@ -58,13 +60,13 @@ class MyPageServiceTest {
     for (int i = 0; i < 30; i++) {
       if (i % 2 != 0) {
         boards.add(
-            Board.builder().title("TestTitle" + i).user(NotTargetUser).authorEmail("NotTargetEmail")
+            Board.builder().title("TestTitle" + i).user(NotTargetUser).nickname(NotTargetUser.getNickname())
                 .content("<p>내용 예시 " + i + "</p>")
                 .commentsCount(ThreadLocalRandom.current().nextInt(1, 101))
                 .bookmarksCount(ThreadLocalRandom.current().nextInt(1, 101)).build());
       } else {
         boards.add(
-            Board.builder().user(user).authorEmail(newUser.getEmail())
+            Board.builder().user(user).nickname(user.getNickname())
                 .content("<p>내용 예시 " + i + "</p>")
                 .commentsCount(ThreadLocalRandom.current().nextInt(1, 101))
                 .bookmarksCount(ThreadLocalRandom.current().nextInt(1, 101)).build());
@@ -81,7 +83,7 @@ class MyPageServiceTest {
   @Test
   @DisplayName("작성자가 올바른 사람인지 확인")
   void MyPage_success() throws Exception {
-    String email = "TargetEmail";
+    String email = "target";
     int page = 1;
     long startTime = System.nanoTime();
     Page<Board> rep = myPageService.myPageBoard(email, page);
@@ -96,4 +98,3 @@ class MyPageServiceTest {
     log.info("realJson == {}", realJson);
   }
 }
-

--- a/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
+++ b/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
@@ -48,13 +48,13 @@ class MyPageServiceUnitTest {
   @Test
   @DisplayName("존재하지 않는 사용자가 북마크 페이지 조회시 USER_NOT_FOUND 예외 발생")
   void testMyPageBookmark_UserNotFound() {
-    String email = "nouser@example.com";
+    String nickname = "nouser";
     int page = 1;
 
-    when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+    when(userRepository.findByNickname(nickname)).thenReturn(Optional.empty());
 
     CustomException ex = assertThrows(CustomException.class,
-        () -> service.myPageBookmark(email, page));
+        () -> service.myPageBookmark(nickname, page));
 
     log.info("ex.getErrorCode() == {}", ex.getErrorCode());
   }
@@ -62,25 +62,26 @@ class MyPageServiceUnitTest {
   @Test
   @DisplayName("존재하는 사용자가 북마크 페이지 조회 시 정상 결과 반환")
   void testMyPageBookmark_Success() {
-    String email = "user@example.com";
+    String nickname = "user";
     int pageNumber = 1;
     int pageSize = 6;
 
     User newUser = User.builder()
         .email("user@example.com")
+        .nickname(nickname)
         .build();
-    when(userRepository.findByEmail(email)).thenReturn(Optional.of(newUser));
+    when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(newUser));
 
     List<Long> bookmarkIds = List.of(10L, 20L, 30L);
     Pageable pageable = PageRequest.of(pageNumber - 1, pageSize,
         Sort.by(Sort.Direction.DESC, "createdAt"));
     Page<Long> idPage = new PageImpl<>(bookmarkIds, pageable, bookmarkIds.size());
-    when(myPageBookMarkRepository.findBookMarksByNickname(email, pageable))
+    when(myPageBookMarkRepository.findBookMarksByNickname(nickname, pageable))
         .thenReturn(idPage);
 
     Board b1 = Board.builder()
         .title("타이틀1")
-        .authorEmail(email)
+        .nickname(nickname)
         .category(Category.book)
         .content("내용1")
         .commentsCount(0)
@@ -90,7 +91,7 @@ class MyPageServiceUnitTest {
 
     Board b2 = Board.builder()
         .title("타이틀2")
-        .authorEmail(email)
+        .nickname(nickname)
         .category(Category.book)
         .content("내용2")
         .commentsCount(0)
@@ -100,7 +101,7 @@ class MyPageServiceUnitTest {
 
     Board b3 = Board.builder()
         .title("타이틀3")
-        .authorEmail(email)
+        .nickname(nickname)
         .category(Category.book)
         .content("내용3")
         .commentsCount(0)
@@ -111,7 +112,7 @@ class MyPageServiceUnitTest {
     when(myPageRepository.findAllById(bookmarkIds))
         .thenReturn(List.of(b2, b3, b1));
 
-    Page<Board> result = service.myPageBookmark(email, pageNumber);
+    Page<Board> result = service.myPageBookmark(nickname, pageNumber);
 
     List<Long> resultIds = result.getContent().stream()
         .map(Board::getId)


### PR DESCRIPTION
## 👀제목  
MyPage 리팩토링 (닉네임 기반 전환 & 디코딩 처리)  

## 🙋변경 사항  
- `MyPageController`에서 닉네임(URL 인코딩된 값) 디코딩 처리 추가 후 서비스 호출  
- `myPageBoard`, `myPageBookmark` 서비스 호출 시 **nickname**을 기준으로 동작하도록 변경  
- 컨트롤러 테스트(`MyPageControllerTest`)에서 쿠키를 `userEmail` → `userNickname`으로 교체  
- 서비스/테스트 코드 전반에서 `Board.authorEmail` 사용을 `Board.nickname` 사용으로 일관화  
- 단위 테스트(`MyPageServiceUnitTest`)에서 User 조회를 `findByEmail` → `findByNickname`으로 변경  

## 💎설명  
MyPage 영역은 사용자 식별에 이메일이 아닌 닉네임을 표준으로 삼도록 리팩토링했습니다.  
외부(브라우저)에서 전달되는 `userNickname` 쿠키는 URL 인코딩되어 들어올 수 있으므로, 컨트롤러에서 `URLDecoder`를 통해 복원한 뒤 서비스 레이어로 전달합니다.  
이와 함께 테스트 데이터/시나리오도 닉네임을 중심으로 재작성하여 도메인 전반의 식별 기준을 통일했습니다.  

## 🔨테스트 방법  
1. `GET /users/{nickname}/reviews?page=0` 호출 시, 닉네임이 URL 인코딩되어도 올바르게 디코딩되어 목록이 반환되는지 확인  
2. `GET /users/me/reviews?page=1` 호출 시, `userNickname` 쿠키 기반으로 본인 작성 글이 페이징되어 반환되는지 확인  
3. `GET /users/me/bookmarks?page=1` 호출 시, `userNickname` 쿠키 기반으로 북마크 목록이 페이징되어 반환되는지 확인  
4. `MyPageControllerTest`, `MyPageServiceTest`, `MyPageServiceUnitTest` 전 케이스가 통과하는지 확인  

## ⚙성능  
- 닉네임 기준 필터링으로 로직 단순화 → 미미하나마 분기/파싱 비용 감소  
- 컨트롤러에서만 디코딩 수행하여 서비스/리포지토리 계층의 책임을 명확화  

## ℹ️추가 정보  
- 본 변경은 User → Bookmark → Comment → Search에 이어 MyPage까지 **닉네임 기반 일관성**을 완성하는 단계입니다.  
- 쿠키 명세: `userNickname` 사용(브라우저 인코딩 가능성 고려), 서버에서는 반드시 디코딩 후 사용  

## ❌이슈  
- 없음