### PR TITLE
refactor < UsersReviews > :: UserReviews 관한 리팩토링입니다.

### DIFF
--- a/src/main/java/com/modureview/config/SecurityConfig.java
+++ b/src/main/java/com/modureview/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                 "/reviews/*/bookmarks",
                 "/search",
                 "/users/login",
+                "/users/*/reviews",
                 "favicon.io"
             )
             .permitAll()

--- a/src/main/java/com/modureview/controller/BoardController.java
+++ b/src/main/java/com/modureview/controller/BoardController.java
@@ -45,14 +45,13 @@ public class BoardController {
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
+  //완료
   @PostMapping("/reviews/new")
   public ResponseEntity<Map<String, String>> saveBoard(
       @RequestBody BoardSaveRequest boardSaveRequest) {
-
     boardService.htmlSanitizer(boardSaveRequest);
     List<String> imageUuids = boardService.extractImageInfo(boardSaveRequest);
     boardService.saveBoard(boardSaveRequest, imageUuids);
-
     Map<String, String> response = Map.of("message", "게시글이 성공적으로 등록되었습니다.");
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
@@ -61,7 +60,6 @@ public class BoardController {
   public ResponseEntity<?> updateBoard(@PathVariable Long boardId, @RequestBody BoardSaveRequest boardSaveRequest) {
     log.info("boardId == {}", boardId);
     log.info("boardSaveRequest == {}", boardSaveRequest);
-
     boardService.findBoard(boardId);
     boardService.htmlSanitizer(boardSaveRequest);
     List<String> images = boardService.extractImageInfo(boardSaveRequest);

--- a/src/main/java/com/modureview/controller/BoardController.java
+++ b/src/main/java/com/modureview/controller/BoardController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -48,22 +49,26 @@ public class BoardController {
   //완료
   @PostMapping("/reviews/new")
   public ResponseEntity<Map<String, String>> saveBoard(
-      @RequestBody BoardSaveRequest boardSaveRequest) {
+      @RequestBody BoardSaveRequest boardSaveRequest,
+      @CookieValue(name = "userNickname") String nickname) {
     boardService.htmlSanitizer(boardSaveRequest);
     List<String> imageUuids = boardService.extractImageInfo(boardSaveRequest);
-    boardService.saveBoard(boardSaveRequest, imageUuids);
+    boardService.saveBoard(boardSaveRequest,nickname, imageUuids);
     Map<String, String> response = Map.of("message", "게시글이 성공적으로 등록되었습니다.");
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   @PatchMapping("/reviews/{boardId}")
-  public ResponseEntity<?> updateBoard(@PathVariable Long boardId, @RequestBody BoardSaveRequest boardSaveRequest) {
+  public ResponseEntity<?> updateBoard(
+      @PathVariable Long boardId,
+      @RequestBody BoardSaveRequest boardSaveRequest,
+      @CookieValue(name = "userNickname") String nickname) {
     log.info("boardId == {}", boardId);
     log.info("boardSaveRequest == {}", boardSaveRequest);
     boardService.findBoard(boardId);
     boardService.htmlSanitizer(boardSaveRequest);
     List<String> images = boardService.extractImageInfo(boardSaveRequest);
-    boardService.updateBoard(boardSaveRequest, images,boardId);
+    boardService.updateBoard(boardSaveRequest, nickname, images,boardId);
 
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }

--- a/src/main/java/com/modureview/controller/BookmarkController.java
+++ b/src/main/java/com/modureview/controller/BookmarkController.java
@@ -5,6 +5,8 @@ import com.modureview.dto.response.BookmarkDetailResponse;
 import com.modureview.service.BoardService;
 import com.modureview.service.BookmarkService;
 import com.modureview.service.UserService;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -30,34 +32,33 @@ public class BookmarkController {
   public ResponseEntity<BookmarkDetailResponse> getBookMarkDetail(
       @PathVariable Long reviewId,
       @CookieValue(name = "userNickname" , required = false , defaultValue = "null") String nickname) {
-    BookmarkDetailResponse bookMarkDetailResponse = bookmarkService.bookmarkDetail(reviewId, nickname);
+    String decoded = "null".equals(nickname) ? nickname : URLDecoder.decode(nickname, StandardCharsets.UTF_8);
+    BookmarkDetailResponse bookMarkDetailResponse = bookmarkService.bookmarkDetail(reviewId, decoded);
     return ResponseEntity.ok(bookMarkDetailResponse);
 
   }
 
   @PostMapping("reviews/{reviewId}/bookmarks")
   public ResponseEntity<?> addBookmark(@PathVariable Long reviewId,
-     //@RequestBody BookmarkRequest bookmarkRequest,
       @CookieValue (name = "userNickname" , required = true , defaultValue = "null")String nickname) {
     log.info("reviewId == {}", reviewId);
 
-    log.info("nickname == {}", nickname);
-    //String userEmail = bookmarkRequest.userEmail();
+    String decoded = URLDecoder.decode(nickname, StandardCharsets.UTF_8);
+    log.info("nickname == {}", decoded);
     boardService.findBoard(reviewId);
-    //Long userId = userService.findUserId(userEmail);
-    Long userId = userService.findUserIdByNickname(nickname);
-    bookmarkService.saveBookmark(reviewId, userId, nickname);
+    Long userId = userService.findUserIdByNickname(decoded);
+    bookmarkService.saveBookmark(reviewId, userId, decoded);
 
     return new ResponseEntity<>(HttpStatus.CREATED);
   }
 
   @DeleteMapping("reviews/{reviewId}/bookmarks")
   public ResponseEntity<?> deleteBookmark(@PathVariable Long reviewId,
-     //@RequestBody BookmarkRequest bookmarkRequest
       @CookieValue(name = "userNickname" , required = false ,defaultValue = "null") String nickname) {
     log.info("reviewId == {}", reviewId);
-    log.info("nickname == {}", nickname);
-    bookmarkService.deleteBookmark(reviewId, nickname);
+    String decoded = "null".equals(nickname) ? nickname : URLDecoder.decode(nickname, StandardCharsets.UTF_8);
+    log.info("nickname == {}", decoded);
+    bookmarkService.deleteBookmark(reviewId, decoded);
 
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/src/main/java/com/modureview/controller/BookmarkController.java
+++ b/src/main/java/com/modureview/controller/BookmarkController.java
@@ -29,32 +29,35 @@ public class BookmarkController {
   @GetMapping("/reviews/{reviewId}/bookmarks")
   public ResponseEntity<BookmarkDetailResponse> getBookMarkDetail(
       @PathVariable Long reviewId,
-      @CookieValue(name = "userEmail", required = false, defaultValue = "null") String email) {
-    BookmarkDetailResponse bookMarkDetailResponse = bookmarkService.bookmarkDetail(reviewId, email);
+      @CookieValue(name = "userNickname" , required = false , defaultValue = "null") String nickname) {
+    BookmarkDetailResponse bookMarkDetailResponse = bookmarkService.bookmarkDetail(reviewId, nickname);
     return ResponseEntity.ok(bookMarkDetailResponse);
 
   }
 
   @PostMapping("reviews/{reviewId}/bookmarks")
   public ResponseEntity<?> addBookmark(@PathVariable Long reviewId,
-     @RequestBody BookmarkRequest bookmarkRequest) {
+     //@RequestBody BookmarkRequest bookmarkRequest,
+      @CookieValue (name = "userNickname" , required = true , defaultValue = "null")String nickname) {
     log.info("reviewId == {}", reviewId);
-    log.info("bookmarkRequest == {}", bookmarkRequest);
-    String userEmail = bookmarkRequest.userEmail();
+
+    log.info("nickname == {}", nickname);
+    //String userEmail = bookmarkRequest.userEmail();
     boardService.findBoard(reviewId);
-    Long userId = userService.findUserId(userEmail);
-    bookmarkService.saveBookmark(reviewId, userId, userEmail);
+    //Long userId = userService.findUserId(userEmail);
+    Long userId = userService.findUserIdByNickname(nickname);
+    bookmarkService.saveBookmark(reviewId, userId, nickname);
 
     return new ResponseEntity<>(HttpStatus.CREATED);
   }
 
   @DeleteMapping("reviews/{reviewId}/bookmarks")
   public ResponseEntity<?> deleteBookmark(@PathVariable Long reviewId,
-     @RequestBody BookmarkRequest bookmarkRequest) {
+     //@RequestBody BookmarkRequest bookmarkRequest
+      @CookieValue(name = "userNickname" , required = false ,defaultValue = "null") String nickname) {
     log.info("reviewId == {}", reviewId);
-    log.info("bookmarkRequest == {}", bookmarkRequest);
-    String userEmail = bookmarkRequest.userEmail();
-    bookmarkService.deleteBookmark(reviewId, userEmail);
+    log.info("nickname == {}", nickname);
+    bookmarkService.deleteBookmark(reviewId, nickname);
 
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/src/main/java/com/modureview/controller/CommentController.java
+++ b/src/main/java/com/modureview/controller/CommentController.java
@@ -32,7 +32,8 @@ public class CommentController {
   @PostMapping("/reviews/{reviewId}/comments")
   public ResponseEntity<?> addComment(@PathVariable Long reviewId,
       @RequestBody CommentSaveRequest commentSaveRequest) {
-    Long userId = userService.findUserId(commentSaveRequest.userEmail());
+    //Long userId = userService.findUserId(commentSaveRequest.userEmail());
+    Long userId = userService.findUserIdByNickname(commentSaveRequest.nickname());
     commentService.saveComment(reviewId, userId, commentSaveRequest);
 
     return new ResponseEntity<>(HttpStatus.CREATED);

--- a/src/main/java/com/modureview/controller/CommentController.java
+++ b/src/main/java/com/modureview/controller/CommentController.java
@@ -8,11 +8,14 @@ import com.modureview.entity.Comment;
 import com.modureview.service.CommentService;
 import com.modureview.service.UserService;
 import java.util.List;
+
+import jakarta.servlet.http.Cookie;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,10 +34,11 @@ public class CommentController {
 
   @PostMapping("/reviews/{reviewId}/comments")
   public ResponseEntity<?> addComment(@PathVariable Long reviewId,
-      @RequestBody CommentSaveRequest commentSaveRequest) {
+      @RequestBody CommentSaveRequest commentSaveRequest,
+      @CookieValue(name = "userNickname") String nickname) {
     //Long userId = userService.findUserId(commentSaveRequest.userEmail());
-    Long userId = userService.findUserIdByNickname(commentSaveRequest.nickname());
-    commentService.saveComment(reviewId, userId, commentSaveRequest);
+    Long userId = userService.findUserIdByNickname(nickname);
+    commentService.saveComment(reviewId,nickname, userId, commentSaveRequest);
 
     return new ResponseEntity<>(HttpStatus.CREATED);
   }
@@ -53,7 +57,7 @@ public class CommentController {
   @GetMapping("/reviews/{reviewId}/comments")
   public ResponseEntity<CommentListResponse> getCommentList(
       @PathVariable Long reviewId,
-      @RequestParam(name = "page", defaultValue = "1") int page  // 페이지 기본값을 1로 바꿔도 좋습니다
+      @RequestParam(name = "page", defaultValue = "1") int page
   ) {
     Page<Comment> commentPage = commentService.commentList(reviewId, page);
     List<CommentDetailResponse> listComment = commentPage.getContent().stream()

--- a/src/main/java/com/modureview/controller/LoginController.java
+++ b/src/main/java/com/modureview/controller/LoginController.java
@@ -62,7 +62,8 @@ public class LoginController {
 			Arrays.stream(cookies).forEach(cookie -> {
 				if (cookie.getName().equals("accessToken") ||
 					cookie.getName().equals("refreshToken") ||
-					cookie.getName().equals("userEmail")) {
+					cookie.getName().equals("userEmail") ||
+					cookie.getName().equals("userNickname")) {
 					ResponseCookie expiredCookie = jwtTokenService.expireCookie(
 						ResponseCookie.from(cookie.getName(), "").build()
 					);

--- a/src/main/java/com/modureview/controller/MyPageController.java
+++ b/src/main/java/com/modureview/controller/MyPageController.java
@@ -1,5 +1,7 @@
 package com.modureview.controller;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -30,7 +32,8 @@ public class MyPageController {
 		@RequestParam(name = "page", defaultValue = "0") int page
 	) {
 
-		Page<Board> boardPage = myPageService.myPageBoard(nickname, page);
+		String decoded = URLDecoder.decode(nickname, StandardCharsets.UTF_8);
+		Page<Board> boardPage = myPageService.myPageBoard(decoded, page);
 		List<SliceBoardResponse> listMyPage = boardPage.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.toList();
@@ -47,7 +50,8 @@ public class MyPageController {
 		@CookieValue(name = "userNickname") String nickname,
 		@RequestParam(name = "page", defaultValue = "0") int page
 	) {
-		Page<Board> boardMyPage = myPageService.myPageBookmark(nickname, page);
+		String decoded = URLDecoder.decode(nickname, StandardCharsets.UTF_8);
+		Page<Board> boardMyPage = myPageService.myPageBookmark(decoded, page);
 		List<SliceBoardResponse> listMyPage = boardMyPage.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.toList();

--- a/src/main/java/com/modureview/controller/MyPageController.java
+++ b/src/main/java/com/modureview/controller/MyPageController.java
@@ -26,10 +26,11 @@ public class MyPageController {
 
 	@GetMapping("/users/me/reviews")
 	public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getUserBoards(
-		@CookieValue(name = "userEmail") String email,
+		@CookieValue(name = "userNickname") String nickname,
 		@RequestParam(name = "page", defaultValue = "0") int page
 	) {
-		Page<Board> boardPage = myPageService.myPageBoard(email, page);
+
+		Page<Board> boardPage = myPageService.myPageBoard(nickname, page);
 		List<SliceBoardResponse> listMyPage = boardPage.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.toList();
@@ -43,10 +44,10 @@ public class MyPageController {
 
 	@GetMapping("/users/me/bookmarks")
 	public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getBookMarkBoards(
-		@CookieValue(name = "userEmail") String email,
+		@CookieValue(name = "userNickname") String nickname,
 		@RequestParam(name = "page", defaultValue = "0") int page
 	) {
-		Page<Board> boardMyPage = myPageService.myPageBookmark(email, page);
+		Page<Board> boardMyPage = myPageService.myPageBookmark(nickname, page);
 		List<SliceBoardResponse> listMyPage = boardMyPage.getContent().stream()
 			.map(SliceBoardResponse::fromEntity)
 			.toList();

--- a/src/main/java/com/modureview/controller/SearchController.java
+++ b/src/main/java/com/modureview/controller/SearchController.java
@@ -1,8 +1,8 @@
 package com.modureview.controller;
 
-import com.modureview.dto.response.BoardSearchResponse;
 import com.modureview.dto.response.CustomPageResponse;
 import com.modureview.dto.response.CustomSlicePageResponse;
+import com.modureview.dto.response.SliceBoardResponse;
 import com.modureview.entity.Board;
 import com.modureview.entity.Category;
 import com.modureview.service.SearchService;
@@ -28,7 +28,7 @@ public class SearchController {
 
 
   @GetMapping("/search")
-  public ResponseEntity<CustomPageResponse<BoardSearchResponse>> getBoardSearch(
+  public ResponseEntity<CustomPageResponse<SliceBoardResponse>> getBoardSearch(
       @RequestParam(name = "keyword") String keyword,
       @RequestParam(name = "page", defaultValue = "0") int page,
       @RequestParam(name = "sort", defaultValue = "recent") String sort
@@ -36,10 +36,10 @@ public class SearchController {
     String decodeKeyword = URLDecoder.decode(keyword, "UTF-8");
     log.info("Searching for " + decodeKeyword);
     Page<Board> boardPage = searchService.boardSearch(decodeKeyword, page, sort);
-    List<BoardSearchResponse> listSearchBoard = boardPage.getContent().stream()
-        .map(BoardSearchResponse::fromEntity)
+    List<SliceBoardResponse> listSearchBoard = boardPage.getContent().stream()
+        .map(SliceBoardResponse::fromEntity)
         .toList();
-    CustomPageResponse<BoardSearchResponse> SearchPage = new CustomPageResponse<>(
+    CustomPageResponse<SliceBoardResponse> SearchPage = new CustomPageResponse<>(
         listSearchBoard,
         boardPage.getNumber() + 1,
         boardPage.getTotalPages()
@@ -50,13 +50,13 @@ public class SearchController {
 
 
   @GetMapping("/reviews")
-  public ResponseEntity<CustomSlicePageResponse<BoardSearchResponse>> getBoardsByCategory(
+  public ResponseEntity<CustomSlicePageResponse<SliceBoardResponse>> getBoardsByCategory(
       @RequestParam(name = "categoryId") Category category,
       @RequestParam(name = "cursor", defaultValue = "0") Long cursorId,
       @RequestParam(name = "sort", defaultValue = "recent") String sort) {
     Slice<Board> boardSlice = searchService.getCategoryBoard(category, cursorId, sort);
-    List<BoardSearchResponse> dtoList = boardSlice.getContent().stream()
-        .map(BoardSearchResponse::fromEntity)
+    List<SliceBoardResponse> dtoList = boardSlice.getContent().stream()
+        .map(SliceBoardResponse::fromEntity)
         .collect(Collectors.toList());
 
     Long nextCursorValue = null;
@@ -65,13 +65,10 @@ public class SearchController {
       nextCursorValue = lastBoardInSlice.getId();
     }
 
-    CustomSlicePageResponse<BoardSearchResponse> customResponse = new CustomSlicePageResponse<>(
+    CustomSlicePageResponse<SliceBoardResponse> customResponse = CustomSlicePageResponse.of(
         dtoList,
         nextCursorValue,
-        boardSlice.hasNext(),
-        boardSlice.getNumberOfElements(),
-        boardSlice.getSize(),
-        boardSlice.isFirst()
+        boardSlice.hasNext()
     );
 
     return ResponseEntity.ok(customResponse);

--- a/src/main/java/com/modureview/controller/UserReviewsController.java
+++ b/src/main/java/com/modureview/controller/UserReviewsController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.modureview.dto.response.CustomSlicePageResponse;
-import com.modureview.dto.response.UserReviewsResponse;
+import com.modureview.dto.response.SliceBoardResponse;
 import com.modureview.entity.Board;
 import com.modureview.service.UserReviewsService;
 
@@ -24,17 +24,15 @@ import lombok.extern.slf4j.Slf4j;
 public class UserReviewsController {
 	private final UserReviewsService userReviewsService;
 
-	@GetMapping("/users/{memberEmail}")
-    public ResponseEntity<CustomSlicePageResponse<UserReviewsResponse>> getBoardsByUserEmail(
-        @PathVariable String memberEmail,
+	@GetMapping("/users/{nickname}/reviews")
+    public ResponseEntity<CustomSlicePageResponse<SliceBoardResponse>> getBoardsByUserEmail(
+        @PathVariable String nickname,
         @RequestParam(name = "cursor", defaultValue = "0") Long cursor,
         @RequestParam(name = "sort", defaultValue = "recent") String sort
     ) {
-        Slice<Board> boardSlice = userReviewsService.userReviews(memberEmail, cursor, sort);
-        // Count total results for this author once and apply to all DTOs
-        long totalResults = userReviewsService.countByAuthorEmail(memberEmail);
-        List<UserReviewsResponse> dtoList = boardSlice.getContent().stream()
-            .map(board -> UserReviewsResponse.fromEntity(board, (int) totalResults))
+        Slice<Board> boardSlice = userReviewsService.userReviews(nickname, cursor, sort);
+        List<SliceBoardResponse> dtoList = boardSlice.getContent().stream()
+            .map(SliceBoardResponse::fromEntity)
             .collect(Collectors.toList());
 
 		Long nextCursorValue = null;
@@ -43,15 +41,15 @@ public class UserReviewsController {
 			nextCursorValue = lastBoardInSlice.getId();
 		}
 
-        CustomSlicePageResponse<UserReviewsResponse> customResponse = new CustomSlicePageResponse<>(
-            dtoList,
-            nextCursorValue,
-            boardSlice.hasNext(),
-            boardSlice.getNumberOfElements(),
-            boardSlice.getSize(),
-            boardSlice.isFirst()
-        );
+        Long totalResults = userReviewsService.countByNickname(nickname);
 
-		return ResponseEntity.ok(customResponse);
+		CustomSlicePageResponse<SliceBoardResponse> body = CustomSlicePageResponse.of(
+			dtoList,
+			nextCursorValue,
+			boardSlice.hasNext(),
+			totalResults
+		);
+
+		return ResponseEntity.ok(body);
 	}
 }

--- a/src/main/java/com/modureview/dto/request/BoardSaveRequest.java
+++ b/src/main/java/com/modureview/dto/request/BoardSaveRequest.java
@@ -1,5 +1,5 @@
 package com.modureview.dto.request;
 
-public record BoardSaveRequest(String title, String content, String category, String nickname) {
+public record BoardSaveRequest(String title, String content, String category) {
 
 }

--- a/src/main/java/com/modureview/dto/request/BoardSaveRequest.java
+++ b/src/main/java/com/modureview/dto/request/BoardSaveRequest.java
@@ -1,5 +1,5 @@
 package com.modureview.dto.request;
 
-public record BoardSaveRequest(String title, String content, String category, String authorEmail) {
+public record BoardSaveRequest(String title, String content, String category, String nickname) {
 
 }

--- a/src/main/java/com/modureview/dto/request/CommentSaveRequest.java
+++ b/src/main/java/com/modureview/dto/request/CommentSaveRequest.java
@@ -3,6 +3,6 @@ package com.modureview.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.modureview.entity.Category;
 
-public record CommentSaveRequest(@JsonProperty("userNickname") String nickname, Category category,
+public record CommentSaveRequest(Category category,
                                  String content) {
 }

--- a/src/main/java/com/modureview/dto/request/CommentSaveRequest.java
+++ b/src/main/java/com/modureview/dto/request/CommentSaveRequest.java
@@ -3,6 +3,6 @@ package com.modureview.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.modureview.entity.Category;
 
-public record CommentSaveRequest(@JsonProperty("user_email") String userEmail, Category category,
+public record CommentSaveRequest(@JsonProperty("userNickname") String nickname, Category category,
                                  String content) {
 }

--- a/src/main/java/com/modureview/dto/response/BestReviewResponse.java
+++ b/src/main/java/com/modureview/dto/response/BestReviewResponse.java
@@ -9,8 +9,7 @@ public record BestReviewResponse(
 
     Long board_id,
     String title,
-    String author_id,
-    String author_email,
+    String author_nickname,
     String category,
     String preview,
     int comments_count,
@@ -30,8 +29,7 @@ public record BestReviewResponse(
     return new BestReviewResponse(
         board.getId(),
         board.getTitle(),
-        board.getAuthorEmail().split("@")[0],
-        board.getAuthorEmail(),
+        board.getNickname(),
         board.getCategory().name(),
         board.getPreview(),
         board.getCommentsCount(),

--- a/src/main/java/com/modureview/dto/response/BoardDetailResponse.java
+++ b/src/main/java/com/modureview/dto/response/BoardDetailResponse.java
@@ -10,8 +10,7 @@ public record BoardDetailResponse(
     Long board_id,
     String title,
     Category category,
-    String author_email,
-    String author_id,
+    String nickname,
     @JsonFormat(pattern = "yyyy-MM-dd HH시 mm분", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
     LocalDateTime created_at,
     String content

--- a/src/main/java/com/modureview/dto/response/BoardDetailResponse.java
+++ b/src/main/java/com/modureview/dto/response/BoardDetailResponse.java
@@ -10,7 +10,7 @@ public record BoardDetailResponse(
     Long board_id,
     String title,
     Category category,
-    String nickname,
+    String author_nickname,
     @JsonFormat(pattern = "yyyy-MM-dd HH시 mm분", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
     LocalDateTime created_at,
     String content

--- a/src/main/java/com/modureview/dto/response/CommentDetailResponse.java
+++ b/src/main/java/com/modureview/dto/response/CommentDetailResponse.java
@@ -8,21 +8,18 @@ import lombok.Builder;
 @Builder
 public record CommentDetailResponse(
     Long id,
-    String author_id,
-    String author_email,
+    String author_nickname,
     String content,
     @JsonFormat(pattern = "yyyy-MM-dd HH시 mm분", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
     LocalDateTime created_at
 ) {
 
   public static CommentDetailResponse fromEntity(Comment comment) {
-    return CommentDetailResponse.builder()
-        .id(comment.getId())
-        .author_id(comment.getUserEmail().split("@")[0])
-        .author_email(comment.getUserEmail())
-        .content(comment.getContent())
-        .created_at(comment.getCreatedAt())
-        .build();
+      return CommentDetailResponse.builder()
+          .id(comment.getId())
+          .author_nickname(comment.getNickname())
+          .content(comment.getContent())
+          .created_at(comment.getCreatedAt())
+          .build();
   }
-
 }

--- a/src/main/java/com/modureview/dto/response/CustomSlicePageResponse.java
+++ b/src/main/java/com/modureview/dto/response/CustomSlicePageResponse.java
@@ -1,21 +1,40 @@
 package com.modureview.dto.response;
 
 import java.util.List;
+
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@Builder
+
 public class CustomSlicePageResponse<T> {
 
   private final List<T> results;
   private final Long next_cursor;
   private final boolean has_next;
+  private final Long total_results;
 
-
-  public CustomSlicePageResponse(List<T> results, Long next_cursor, boolean has_next,
-      int numberOfElements, int size, boolean first) {
-    this.results = results;
-    this.next_cursor = next_cursor;
-    this.has_next = has_next;
+  public static <T> CustomSlicePageResponse<T> of(List<T> results, Long next_cursor, boolean has_next) {
+    return CustomSlicePageResponse.<T>builder()
+        .results(results)
+        .next_cursor(next_cursor)
+        .has_next(has_next)
+        .build();
   }
+
+  public static <T> CustomSlicePageResponse<T> of(
+      List<T> results , Long next_cursor , boolean has_next , Long total_results
+  ){
+    return CustomSlicePageResponse.<T>builder()
+        .results(results)
+        .next_cursor(next_cursor)
+        .has_next(has_next)
+        .total_results(total_results)
+        .build();
+  }
+
+
 }
 

--- a/src/main/java/com/modureview/dto/response/SliceBoardResponse.java
+++ b/src/main/java/com/modureview/dto/response/SliceBoardResponse.java
@@ -10,8 +10,7 @@ import lombok.Builder;
 public record SliceBoardResponse(
     Long board_id,
     String title,
-    String author_id,
-    String author_email,
+    String author_nickname,
     Category category,
     String preview,
     Integer comments_count,
@@ -29,8 +28,7 @@ public record SliceBoardResponse(
         .board_id(board.getId())
         .title(board.getTitle())
         .category(board.getCategory())
-        .author_id(board.getAuthorEmail().split("@")[0])
-        .author_email(board.getAuthorEmail())
+        .author_nickname(board.getNickname())
         .created_at(board.getCreatedAt())
         .preview(board.getPreview())
         .comments_count(board.getCommentsCount())

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -47,8 +47,8 @@ public class Board {
   @JsonBackReference
   private User user;
 
-  @Column(name="author_email")
-  private String authorEmail;
+  @Column(name = "nickname")
+  private String nickname;
 
   @Enumerated(EnumType.STRING)
   private Category category;
@@ -99,10 +99,10 @@ public class Board {
   }
 
   @Builder
-  public Board(String title, String authorEmail, Category category, String content,
-      Integer commentsCount, Integer bookmarksCount) {
+  public Board(String title, Category category, String content,
+      Integer commentsCount, Integer bookmarksCount , String nickname) {
     this.title = title;
-    this.authorEmail = authorEmail;
+    this.nickname = nickname;
     this.category = category;
     this.content = content;
     this.commentsCount = commentsCount;

--- a/src/main/java/com/modureview/entity/Board.java
+++ b/src/main/java/com/modureview/entity/Board.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -43,7 +44,12 @@ public class Board {
   private String title;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id", nullable = false)
+  @JoinColumn(
+      name = "user_id",
+      referencedColumnName = "id",
+      nullable = false,
+      foreignKey = @ForeignKey(name = "fk_board_user")
+  )
   @JsonBackReference
   private User user;
 
@@ -59,6 +65,8 @@ public class Board {
   @Lob
   @Column(columnDefinition = "TEXT")
   private String content;
+
+  private String author_nickname;
 
   @Lob
   @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/modureview/entity/BookMark.java
+++ b/src/main/java/com/modureview/entity/BookMark.java
@@ -25,6 +25,8 @@ public class BookMark {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  private String nickname;
+
   private String email;
 
   private Long userId;

--- a/src/main/java/com/modureview/entity/Comment.java
+++ b/src/main/java/com/modureview/entity/Comment.java
@@ -31,7 +31,9 @@ public class Comment {
 
   private Long userId;
 
-  private String userEmail;
+  private String nickname;
+
+  //private String userEmail;
 
   private String content;
 

--- a/src/main/java/com/modureview/entity/User.java
+++ b/src/main/java/com/modureview/entity/User.java
@@ -20,7 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/modureview/filter/JwtAuthFilter.java
+++ b/src/main/java/com/modureview/filter/JwtAuthFilter.java
@@ -32,6 +32,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
       "/reviews/*/bookmarks",
       "/search",
       "/users/login",
+      "/users/*/reviews",
       "/favicon.io"
   );
 

--- a/src/main/java/com/modureview/repository/BoardRepository.java
+++ b/src/main/java/com/modureview/repository/BoardRepository.java
@@ -36,8 +36,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
   @Query("SELECT b FROM Board b JOIN FETCH b.user WHERE b.id IN :ids")
   List<Board> findByIdsWithUser(@Param("ids") List<Long> ids);
 
-  Board findByAuthorEmail(String mail);
-
   @Query("SELECT b.commentsCount FROM Board b WHERE b.id = :boardId")
   Integer findCommentsCountById(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/modureview/repository/BookmarkRepository.java
+++ b/src/main/java/com/modureview/repository/BookmarkRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<BookMark, Long> {
 
-  Optional<BookMark> findByEmailAndBoardId(String userEmail, Long boardId);
 
-  Boolean existsByBoardIdAndEmail(Long boardId, String email);
+  Optional<BookMark> findByNicknameAndBoardId(String nickname, Long boardId);
+
+  Boolean existsByNicknameAndBoardId(String nickname, Long boardId);
 
 }

--- a/src/main/java/com/modureview/repository/MyPageBookMarkRepository.java
+++ b/src/main/java/com/modureview/repository/MyPageBookMarkRepository.java
@@ -13,9 +13,9 @@ public interface MyPageBookMarkRepository extends JpaRepository<BookMark, Long> 
   @Query(
       value = "SELECT bm.boardId "
           + "FROM BookMark bm "
-          + "WHERE bm.email = :email"
+          + "WHERE bm.nickname = :nickname"
   )
-  Page<Long> findBookMarksByEmail(String email, Pageable pageable);
+  Page<Long> findBookMarksByNickname(String nickname, Pageable pageable);
 
 
 }

--- a/src/main/java/com/modureview/repository/MyPageRepository.java
+++ b/src/main/java/com/modureview/repository/MyPageRepository.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MyPageRepository extends JpaRepository<Board, Long> {
 
-  @Query(value = "SELECT b FROM Board b WHERE b.authorEmail = :email")
-  Page<Board> findBoardByAuthorEmail(@Param("email") String email, Pageable pageable);
+  @Query(value = "SELECT b FROM Board b WHERE b.nickname = :nickname")
+  Page<Board> findBoardByNickname(@Param("nickname") String nickname, Pageable pageable);
+
+
 
 }

--- a/src/main/java/com/modureview/repository/SearchRepository.java
+++ b/src/main/java/com/modureview/repository/SearchRepository.java
@@ -20,7 +20,7 @@ public interface SearchRepository extends JpaRepository<Board, Long> {
             FROM Board b
             WHERE LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                OR b.content      LIKE CONCAT('%', :keyword, '%')
-               OR LOWER(b.authorEmail) LIKE LOWER(CONCAT('%', :keyword, '%'))
+               OR LOWER(b.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
           """
       ,
       countQuery = """
@@ -28,7 +28,7 @@ public interface SearchRepository extends JpaRepository<Board, Long> {
             FROM Board b
             WHERE LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                OR b.content      LIKE CONCAT('%', :keyword, '%')
-               OR LOWER(b.authorEmail) LIKE LOWER(CONCAT('%', :keyword, '%'))
+               OR LOWER(b.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
           """)
   Page<Board> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 

--- a/src/main/java/com/modureview/repository/UserRepository.java
+++ b/src/main/java/com/modureview/repository/UserRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
+
+  Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/modureview/repository/UserReviewsRepository.java
+++ b/src/main/java/com/modureview/repository/UserReviewsRepository.java
@@ -13,45 +13,60 @@ import com.modureview.entity.Board;
 
 @Repository
 public interface UserReviewsRepository extends JpaRepository<Board, Long> {
-	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
-		+ "AND (b.createdAt < :createdAt OR "
-		+ " (b.createdAt = :createdAt AND b.id < :boardId)) "
-		+ "ORDER BY b.createdAt DESC , b.id DESC")
-	Slice<Board> findByAuthorEmailByCreatedAt(
-		@Param("authorEmail") String authorEmail,
-		@Param("createdAt") LocalDateTime createdAt,
-		@Param("boardId") Long boardId,
-		Pageable pageable
-	);
+    @Query("SELECT b FROM Board b WHERE b.nickname = :nickname "
+        + "AND (b.createdAt < :createdAt OR "
+        + " (b.createdAt = :createdAt AND b.id < :boardId)) "
+        + "ORDER BY b.createdAt DESC , b.id DESC")
+    Slice<Board> findByNicknameByCreatedAt(
+        @Param("nickname") String nickname,
+        @Param("createdAt") LocalDateTime createdAt,
+        @Param("boardId") Long boardId,
+        Pageable pageable
+    );
 
-	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
-		+ "AND(b.bookmarksCount < :bookmarksCount OR "
-		+ "(b.bookmarksCount = :bookmarksCount AND b.id < :boardId)) "
-		+ "ORDER BY b.bookmarksCount DESC , b.id DESC")
-	Slice<Board> findByAuthorEmailByBookmarksCount(
-		@Param("authorEmail") String authorEmail,
-		@Param("bookmarksCount") Integer bookmarksCount,
-		@Param("boardId") Long boardId,
-		Pageable pageable
-	);
+    @Query("SELECT b FROM Board b WHERE b.nickname = :nickname "
+        + "AND(b.bookmarksCount < :bookmarksCount OR "
+        + "(b.bookmarksCount = :bookmarksCount AND b.id < :boardId)) "
+        + "ORDER BY b.bookmarksCount DESC , b.id DESC")
+    Slice<Board> findByNicknameByBookmarksCount(
+        @Param("nickname") String nickname,
+        @Param("bookmarksCount") Integer bookmarksCount,
+        @Param("boardId") Long boardId,
+        Pageable pageable
+    );
 
-	@Query("SELECT b FROM Board b WHERE b.authorEmail = :authorEmail "
-		+ "AND(b.commentsCount < :commentsCount OR "
-		+ "(b.commentsCount = :commentsCount AND b.id < :boardId)) "
-		+ "ORDER BY b.commentsCount DESC , b.id DESC")
-	Slice<Board> findByAuthorEmailByCommentsCount(
-		@Param("authorEmail") String authorEmail,
-		@Param("commentsCount") Integer commentsCount,
-		@Param("boardId") Long boardId,
-		Pageable pageable
-	);
+    @Query("SELECT b FROM Board b WHERE b.nickname = :nickname "
+        + "AND(b.commentsCount < :commentsCount OR "
+        + "(b.commentsCount = :commentsCount AND b.id < :boardId)) "
+        + "ORDER BY b.commentsCount DESC , b.id DESC")
+    Slice<Board> findByNicknameByCommentsCount(
+        @Param("nickname") String nickname,
+        @Param("commentsCount") Integer commentsCount,
+        @Param("boardId") Long boardId,
+        Pageable pageable
+    );
 
-	Board findTopByAuthorEmailOrderByCreatedAtDesc(String authorEmail);
+    long countByNickname(String nickname);
 
-	Board findTopByAuthorEmailOrderByBookmarksCountDesc(String authorEmail);
+    @Query("SELECT b FROM Board b WHERE b.nickname = :nickname ORDER by b.createdAt DESC , b.id DESC")
+    Slice<Board> findByNicknameOrderByCreatedAtFirst(
+        @Param("nickname") String nickname,
+        Pageable pageable
+    );
+    @Query("SELECT b FROM Board b WHERE b.nickname = :nickname ORDER BY b.bookmarksCount DESC , b.id DESC")
+    Slice<Board> findByNicknameOrderByBookmarksCountFirst(
+        @Param("nickname") String nickname,
+        Pageable pageable
+    );
 
-	Board findTopByAuthorEmailOrderByCommentsCountDesc(String authorEmail);
+    @Query("SELECT b FROM Board b WHERE b.nickname = :nickname ORDER BY b.commentsCount DESC, b.id DESC")
+    Slice<Board> findByNicknameOrderByCommentsCountFirst(
+        @Param("nickname") String nickname,
+        Pageable pageable
+    );
 
-	long countByAuthorEmail(String authorEmail);
+
+
+
 
 }

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -73,7 +73,7 @@ public class BoardService {
         .board_id(findBoard.getId())
         .title(findBoard.getTitle())
         .category(findBoard.getCategory())
-        .nickname(findBoard.getNickname())
+        .author_nickname(findBoard.getNickname())
         .created_at(findBoard.getCreatedAt())
         .content(findBoard.getContent())
         .build();
@@ -135,8 +135,8 @@ public class BoardService {
   }
 
   @Transactional
-  public void saveBoard(BoardSaveRequest request, List<String> imageUuids) {
-    User user = userRepository.findByNickname(request.nickname()).get();
+  public void saveBoard(BoardSaveRequest request,String nickname, List<String> imageUuids) {
+    User user = userRepository.findByNickname(nickname).get();
     String thumbnail = imageUuids.isEmpty() ? defaultImageUrl : cndUrl + imageUuids.get(0);
     String plainText = Jsoup.parse(request.content()).text();
     String preview;
@@ -151,7 +151,7 @@ public class BoardService {
         .content(request.content())
         .user(user)
         .preview(preview)
-        .nickname(request.nickname())
+        .nickname(nickname)
         .imageUrl(thumbnail)
         .category(Category.valueOf(request.category()))
         .build();
@@ -216,8 +216,8 @@ public class BoardService {
   }
 
   @Transactional
-  public void updateBoard(BoardSaveRequest request, List<String> imageUuids, Long boardId) {
-    User user = userRepository.findByNickname(request.nickname()).get();
+  public void updateBoard(BoardSaveRequest request, String nickname, List<String> imageUuids, Long boardId) {
+    User user = userRepository.findByNickname(nickname).get();
     String thumbnail = imageUuids.isEmpty() ? defaultImageUrl : cndUrl + imageUuids.get(0);
     String plainText = Jsoup.parse(request.content()).text();
     String preview;
@@ -233,7 +233,7 @@ public class BoardService {
     foundBoard.setContent(request.content());
     foundBoard.setUser(user);
     foundBoard.setPreview(preview);
-    foundBoard.setNickname(request.nickname());
+    foundBoard.setNickname(nickname);
     foundBoard.setImageUrl(thumbnail);
     foundBoard.setCategory(Category.valueOf(request.category()));
 

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -73,8 +73,7 @@ public class BoardService {
         .board_id(findBoard.getId())
         .title(findBoard.getTitle())
         .category(findBoard.getCategory())
-        .author_email(findBoard.getAuthorEmail())
-        .author_id(findBoard.getAuthorEmail().split("@")[0])
+        .nickname(findBoard.getNickname())
         .created_at(findBoard.getCreatedAt())
         .content(findBoard.getContent())
         .build();
@@ -137,7 +136,7 @@ public class BoardService {
 
   @Transactional
   public void saveBoard(BoardSaveRequest request, List<String> imageUuids) {
-    User user = userRepository.findByEmail(request.authorEmail()).get();
+    User user = userRepository.findByNickname(request.nickname()).get();
     String thumbnail = imageUuids.isEmpty() ? defaultImageUrl : cndUrl + imageUuids.get(0);
     String plainText = Jsoup.parse(request.content()).text();
     String preview;
@@ -152,7 +151,7 @@ public class BoardService {
         .content(request.content())
         .user(user)
         .preview(preview)
-        .authorEmail(request.authorEmail())
+        .nickname(request.nickname())
         .imageUrl(thumbnail)
         .category(Category.valueOf(request.category()))
         .build();
@@ -218,7 +217,7 @@ public class BoardService {
 
   @Transactional
   public void updateBoard(BoardSaveRequest request, List<String> imageUuids, Long boardId) {
-    User user = userRepository.findByEmail(request.authorEmail()).get();
+    User user = userRepository.findByNickname(request.nickname()).get();
     String thumbnail = imageUuids.isEmpty() ? defaultImageUrl : cndUrl + imageUuids.get(0);
     String plainText = Jsoup.parse(request.content()).text();
     String preview;
@@ -234,7 +233,7 @@ public class BoardService {
     foundBoard.setContent(request.content());
     foundBoard.setUser(user);
     foundBoard.setPreview(preview);
-    foundBoard.setAuthorEmail(request.authorEmail());
+    foundBoard.setNickname(request.nickname());
     foundBoard.setImageUrl(thumbnail);
     foundBoard.setCategory(Category.valueOf(request.category()));
 

--- a/src/main/java/com/modureview/service/BookmarkService.java
+++ b/src/main/java/com/modureview/service/BookmarkService.java
@@ -30,11 +30,11 @@ public class BookmarkService {
   private final StringRedisTemplate stringRedisTemplate;
 
   @Transactional
-  public void saveBookmark(Long boardId, Long userId, String email) {
+  public void saveBookmark(Long boardId, Long userId, String nickname) {
     BookMark bookmark = BookMark.builder()
         .boardId(boardId)
         .userId(userId)
-        .email(email)
+        .nickname(nickname)
         .build();
 
     bookmarkRepository.save(bookmark);
@@ -46,8 +46,8 @@ public class BookmarkService {
   }
 
   @Transactional
-  public void deleteBookmark(Long boardId, String email) {
-    BookMark bookmarks = bookmarkRepository.findByEmailAndBoardId(email, boardId)
+  public void deleteBookmark(Long boardId, String nickname) {
+    BookMark bookmarks = bookmarkRepository.findByNicknameAndBoardId(nickname, boardId)
         .orElseThrow(() -> new BookmarkNotExistException(BookmarkErrorCode.BOOKMARK_NOT_FOUND));
     bookmarkRepository.delete(bookmarks);
 
@@ -57,18 +57,18 @@ public class BookmarkService {
     });
   }
 
-  public BookmarkDetailResponse bookmarkDetail(Long reviewId, String email) {
+  public BookmarkDetailResponse bookmarkDetail(Long reviewId, String nickname) {
     log.info("reviewId == {}", reviewId);
-    log.info("email    == {}", email);
+    log.info("email    == {}", nickname);
 
     Board targetBoard = boardRepository.findById(reviewId)
         .orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
     
-    if (!"null".equals(email)) {
-      userRepository.findByEmail(email)
+    if (!"null".equals(nickname)) {
+      userRepository.findByNickname(nickname)
           .orElseThrow(() -> new CustomException(JwtErrorCode.FORBIDDEN));
 
-      boolean hasBookmark = bookmarkRepository.existsByBoardIdAndEmail(reviewId, email);
+      boolean hasBookmark = bookmarkRepository.existsByNicknameAndBoardId(nickname, reviewId);
       return BookmarkDetailResponse.fromEntity(
           hasBookmark,
           targetBoard.getBookmarksCount()

--- a/src/main/java/com/modureview/service/CommentService.java
+++ b/src/main/java/com/modureview/service/CommentService.java
@@ -24,7 +24,8 @@ public class CommentService {
   public void saveComment(Long boardId, Long userId, CommentSaveRequest commentSaveRequest) {
     Comment comment = Comment.builder()
         .boardId(boardId)
-        .userEmail(commentSaveRequest.userEmail())
+        //.userEmail(commentSaveRequest.userEmail())
+        .nickname(commentSaveRequest.nickname())
         .userId(userId)
         .content(commentSaveRequest.content())
         .build();

--- a/src/main/java/com/modureview/service/CommentService.java
+++ b/src/main/java/com/modureview/service/CommentService.java
@@ -21,11 +21,10 @@ public class CommentService {
   private final CommentRepository commentRepository;
   private final BoardRepository boardRepository;
 
-  public void saveComment(Long boardId, Long userId, CommentSaveRequest commentSaveRequest) {
+  public void saveComment(Long boardId,String nickname, Long userId, CommentSaveRequest commentSaveRequest) {
     Comment comment = Comment.builder()
         .boardId(boardId)
-        //.userEmail(commentSaveRequest.userEmail())
-        .nickname(commentSaveRequest.nickname())
+        .nickname(nickname)
         .userId(userId)
         .content(commentSaveRequest.content())
         .build();

--- a/src/main/java/com/modureview/service/JwtTokenService.java
+++ b/src/main/java/com/modureview/service/JwtTokenService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@lombok.RequiredArgsConstructor
 public class JwtTokenService {
 
   @Value("${jwt.secret}")
@@ -34,12 +35,18 @@ public class JwtTokenService {
   }
   private final Long accessTokenExpire = 60 * 60L;
   private final Long refreshTokenExpire = 30 * 24 * 60 * 60L;
+  private final com.modureview.repository.UserRepository userRepository;
 
   public List<ResponseCookie> loginTokenIssue(String userEmail) {
+    String nickname = userRepository.findByEmail(userEmail)
+        .map(com.modureview.entity.User::getNickname)
+        .orElse("익명");
+
     return List.of(
         createAccessToken(userEmail),
         createRefreshToken(userEmail),
-        createUserEmailCookie(userEmail)
+        createUserEmailCookie(userEmail),
+        createNicknameCookie(nickname)
     );
   }
 
@@ -55,6 +62,11 @@ public class JwtTokenService {
 
   public ResponseCookie createUserEmailCookie(String userEmail) {
     return createCookie("userEmail", userEmail, refreshTokenExpire, true);
+  }
+
+  public ResponseCookie createNicknameCookie(String nickname) {
+    // nickname may contain non-ASCII (e.g., Korean); ensure cookie-safe value
+    return createCookie("userNickname", nickname, refreshTokenExpire, false);
   }
 
   public void validateToken(String token) {
@@ -91,7 +103,18 @@ public class JwtTokenService {
   }
 
   private ResponseCookie createCookie(String name, String value, long maxAge, boolean httpOnly) {
-    return ResponseCookie.from(name, value)
+    String safeValue = value;
+    // RFC6265 allows only US-ASCII in cookie value; encode when non-ASCII is present
+    if (!isAscii(value)) {
+      try {
+        safeValue = java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        // Fallback to empty if encoding somehow fails
+        safeValue = "";
+      }
+    }
+
+    return ResponseCookie.from(name, safeValue)
         .httpOnly(httpOnly)
         .secure(true)
         .sameSite("LAX")
@@ -99,6 +122,13 @@ public class JwtTokenService {
         .maxAge(maxAge)
         .domain(".modu-review.com")
         .build();
+  }
+
+  private boolean isAscii(String s) {
+    for (int i = 0; i < s.length(); i++) {
+      if (s.charAt(i) > 0x7F) return false;
+    }
+    return true;
   }
 
   public Optional<String> extractCookie(HttpServletRequest request, String cookieName) {
@@ -131,4 +161,3 @@ public class JwtTokenService {
         .build();
   }
 }
-

--- a/src/main/java/com/modureview/service/MyPageService.java
+++ b/src/main/java/com/modureview/service/MyPageService.java
@@ -22,6 +22,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
+
+//email -> 완료
 @Slf4j
 @Service
 @Transactional
@@ -32,24 +34,24 @@ public class MyPageService {
   private final MyPageRepository myPageRepository;
   private final MyPageBookMarkRepository myPageBookMarkRepository;
 
-  public Page<Board> myPageBoard(String email, int page) {
+  public Page<Board> myPageBoard(String nickname, int page) {
     Sort sortCriteria = Sort.by(Direction.DESC, "createdAt");
     Pageable pageable = PageRequest.of(page - 1, 6, sortCriteria);
 
-    if (userRepository.findByEmail(email).isPresent()) {
-      return myPageRepository.findBoardByAuthorEmail(email, pageable);
+    if (userRepository.findByNickname(nickname).isPresent()) {
+      return myPageRepository.findBoardByNickname(nickname, pageable);
     }
     throw new CustomException(UserErrorCode.USER_NOT_FOUND);
   }
 
-  public Page<Board> myPageBookmark(String email, int page) {
+  public Page<Board> myPageBookmark(String nickname, int page) {
     Sort sortCriteria = Sort.by(Direction.DESC, "createdAt");
     Pageable pageable = PageRequest.of(page - 1, 6, sortCriteria);
-    if (userRepository.findByEmail(email).isEmpty()) {
+    if (userRepository.findByNickname(nickname).isEmpty()) {
       throw new CustomException(UserErrorCode.USER_NOT_FOUND);
     }
 
-    Page<Long> boardIdPage = myPageBookMarkRepository.findBookMarksByEmail(email, pageable);
+    Page<Long> boardIdPage = myPageBookMarkRepository.findBookMarksByNickname(nickname, pageable);
     List<Long> boardIds = boardIdPage.getContent();
     List<Board> boardList = myPageRepository.findAllById(boardIds);
     Map<Long, Board> boardMap = boardList.stream()
@@ -59,9 +61,5 @@ public class MyPageService {
         .filter(Objects::nonNull)
         .toList();
     return new PageImpl<>(sortedBoards, pageable, boardIdPage.getTotalElements());
-
-
   }
-
-
 }

--- a/src/main/java/com/modureview/service/UserReviewsService.java
+++ b/src/main/java/com/modureview/service/UserReviewsService.java
@@ -23,59 +23,47 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 @Slf4j
 public class UserReviewsService {
-	private final UserReviewsRepository userReviewsRepository;
-	private final BoardRepository boardRepository;
+    private final UserReviewsRepository userReviewsRepository;
+    private final BoardRepository boardRepository;
 
-	public Slice<Board> userReviews(String nickname, Long cursorId, String sort) {
-		Pageable pageable = PageRequest.of(0, 6);
-		log.info("nickname == {}", nickname);
-		log.info("cursorId == {}", cursorId);
-		log.info("sort == {}", sort);
+    public Slice<Board> userReviews(String nickname, Long cursorId, String sort)
+    {
 
-		Board targetBoard;
+        Pageable pageable = PageRequest.of(0, 6);
+        log.info("nickname == {}", nickname);
+        log.info("cursorId == {}", cursorId);
+        log.info("sort == {}", sort);
 
-		if (cursorId == null || cursorId == 0L) {
-			switch (sort) {
-				case "recent":
-					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
-					break;
-				case "hotbookmarks":
-					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByBookmarksCountDesc(nickname);
-					break;
-				case "hotcomments":
-					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCommentsCountDesc(nickname);
-					break;
-				default:
-					targetBoard = userReviewsRepository.findTopByAuthorEmailOrderByCreatedAtDesc(nickname);
-			}
-			
-			// 사용자의 게시글이 없는 경우 빈 Slice 반환
-			if (targetBoard == null) {
-				return new SliceImpl<>(new ArrayList<>(), pageable, false);
-			}
-			
-		} else {
-			targetBoard = boardRepository.findById(cursorId)
-				.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
-		}
-		switch (sort) {
-			case "recent":
-				return userReviewsRepository.findByAuthorEmailByCreatedAt(nickname, targetBoard.getCreatedAt(),
-					targetBoard.getId(), pageable);
-			case "hotbookmarks":
-				return userReviewsRepository.findByAuthorEmailByBookmarksCount(nickname,
-					targetBoard.getBookmarksCount(), targetBoard.getId(), pageable);
-			case "hotcomments":
-				return userReviewsRepository.findByAuthorEmailByCommentsCount(nickname,
-					targetBoard.getCommentsCount(), targetBoard.getId(), pageable);
+        boolean isFirstPage = (cursorId == null || cursorId == 0L);
 
-		}
-		return userReviewsRepository.findByAuthorEmailByCreatedAt(nickname, targetBoard.getCreatedAt(),
-			targetBoard.getId(), pageable);
-	}
+        if (isFirstPage) {
+            return switch (sort) {
+                case "hotbookmarks" -> userReviewsRepository.findByNicknameOrderByBookmarksCountFirst(nickname, pageable);
+                case "hotcomments" -> userReviewsRepository.findByNicknameOrderByCommentsCountFirst(nickname, pageable);
+                case "recent" -> userReviewsRepository.findByNicknameOrderByCreatedAtFirst(nickname, pageable)
+                ;
+                default -> userReviewsRepository.findByNicknameOrderByCreatedAtFirst(nickname, pageable)
+                ;
+            };
+        } else {
+            Board anchor = boardRepository.findById(cursorId)
+                .orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
 
-	public long countByAuthorEmail(String authorEmail) {
-		return userReviewsRepository.countByAuthorEmail(authorEmail);
-	}
+            return switch (sort) {
+                case "hotbookmarks" -> userReviewsRepository.findByNicknameByBookmarksCount(
+                    nickname, anchor.getBookmarksCount(), anchor.getId(), pageable);
+                case "hotcomments" -> userReviewsRepository.findByNicknameByCommentsCount(
+                    nickname, anchor.getCommentsCount(), anchor.getId(), pageable);
+                case "recent" -> userReviewsRepository.findByNicknameByCreatedAt
+                    (
+                        nickname, anchor.getCreatedAt(), anchor.getId(), pageable);
+                default -> userReviewsRepository.findByNicknameByCreatedAt(
+                    nickname, anchor.getCreatedAt(), anchor.getId(), pageable);
+            };
+        }
+    }
 
+    public long countByNickname(String nickname) {
+        return userReviewsRepository.countByNickname(nickname);
+    }
 }

--- a/src/main/java/com/modureview/service/UserService.java
+++ b/src/main/java/com/modureview/service/UserService.java
@@ -14,4 +14,9 @@ public class UserService {
     User user = userRepository.findByEmail(email).get();
     return user.getId();
   }
+
+  public Long findUserIdByNickname(String nickname) {
+    User user = userRepository.findByNickname(nickname).get();
+    return user.getId();
+  }
 }

--- a/src/test/java/com/modureview/controller/BoardCategoryBoardControllerTest.java
+++ b/src/test/java/com/modureview/controller/BoardCategoryBoardControllerTest.java
@@ -49,7 +49,7 @@ class BoardCategoryBoardControllerTest {
       boards.add(
           Board.builder()
               .title("테스트" + i)
-              .authorEmail("작성자" + i)
+              .nickname("작성자" + i)
               .category(Category.car)
               .content("<p>내용 예시 " + i + "<p/>")
               .commentsCount(i + i)
@@ -70,8 +70,8 @@ class BoardCategoryBoardControllerTest {
   void Category_success_reviews_recent() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(get("/reviews")
-            .param("category", "car")
-            .param("cursorId", "0")
+            .param("categoryId", "car")
+            .param("cursor", "0")
             .param("sort", "recent")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -94,8 +94,8 @@ class BoardCategoryBoardControllerTest {
     log.info("prettyJson == {}", prettyJson);
 
     MvcResult mvcResult1 = mockMvc.perform(get("/reviews")
-            .param("category", "car")
-            .param("cursorId", "25")
+            .param("categoryId", "car")
+            .param("cursor", "25")
             .param("sort", "recent")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())

--- a/src/test/java/com/modureview/controller/BoardControllerTest.java
+++ b/src/test/java/com/modureview/controller/BoardControllerTest.java
@@ -8,7 +8,10 @@ import com.modureview.entity.Board;
 import com.modureview.repository.BoardRepository;
 import com.modureview.repository.UserRepository;
 import com.modureview.utill.TestUtil;
+import com.modureview.service.utill.SummarizationService;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +23,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -38,7 +44,10 @@ class BoardControllerTest {
 
   private TestUtil testUtil;
 
+  @MockBean
+  private SummarizationService summarizationService;
 
+  
   @BeforeEach
   void setUp() {
     this.testUtil = new TestUtil();
@@ -71,6 +80,117 @@ class BoardControllerTest {
 
     log.info("Formatted JSON Response:");
     log.info("prettyJson == {}", prettyJson);
+  }
+
+  @Test
+  @DisplayName("POST /reviews/new XSS 차단: script 포함 시 400")
+  void createBoard_rejects_xss_script() throws Exception {
+    // given
+    String email = "xss@test.com";
+    userRepository.save(testUtil.newUser(email));
+
+    Map<String, Object> req = new HashMap<>();
+    req.put("title", "악성 스크립트 테스트");
+    req.put("content", "<p>정상</p><script>alert('x')</script>");
+    req.put("category", "car");
+    req.put("nickname", email.split("@")[0]);
+
+    String json = objectMapper.writeValueAsString(req);
+
+    // when/then
+    mockMvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/reviews/new")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("PATCH /reviews/{id} XSS 차단: onerror 포함 시 400")
+  void updateBoard_rejects_xss_onerror() throws Exception {
+    // given: 기존 게시글
+    String email = "owner2@test.com";
+    Board board = testUtil.newBoard(userRepository.save(testUtil.newUser(email)));
+    board = boardRepository.save(board);
+
+    Map<String, Object> req = new HashMap<>();
+    req.put("title", "수정 제목");
+    req.put("content", "<img src=\"a.png\" onerror=\"alert(1)\"/>");
+    req.put("category", "car");
+    req.put("nickname", email.split("@")[0]);
+
+    String json = objectMapper.writeValueAsString(req);
+
+    // when/then
+    mockMvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/reviews/{boardId}", board.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("POST /reviews/new 닉네임 기반 저장 성공")
+  void createBoard_withNickname_success() throws Exception {
+    // given: 사용자와 요청 바디
+    String email = "creator@test.com";
+    userRepository.save(testUtil.newUser(email));
+
+    when(summarizationService.summarize(anyString(), anyString())).thenReturn("요약 본문");
+
+    Map<String, Object> req = new HashMap<>();
+    req.put("title", "새 게시글 제목");
+    req.put("content", "<p>내용</p><img src=\"https://cdn.example.com/uuid-1111.png\"/>");
+    req.put("category", "car");
+    req.put("nickname", email.split("@")[0]);
+
+    String json = objectMapper.writeValueAsString(req);
+
+    // when
+    MvcResult res = mockMvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/reviews/new")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andReturn();
+
+    // then
+    String body = res.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    log.info("[CREATE] response: {}", body);
+  }
+
+  @Test
+  @DisplayName("PATCH /reviews/{id} 닉네임 기반 수정 성공")
+  void updateBoard_withNickname_success() throws Exception {
+    // given: 기존 게시글 및 사용자
+    String email = "owner@test.com";
+    Board board = testUtil.newBoard(userRepository.save(testUtil.newUser(email)));
+    board = boardRepository.save(board);
+
+    when(summarizationService.summarize(anyString(), anyString())).thenReturn("요약 본문");
+
+    Map<String, Object> req = new HashMap<>();
+    req.put("title", "수정된 제목");
+    req.put("content", "<p>수정된 내용</p><img src=\"https://cdn.example.com/uuid-2222.jpg\"/>");
+    req.put("category", "car");
+    req.put("nickname", email.split("@")[0]);
+
+    String json = objectMapper.writeValueAsString(req);
+
+    // when
+    mockMvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/reviews/{boardId}", board.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+        .andExpect(status().isNoContent());
+
+    // then: DB 반영 확인
+    Board updated = boardRepository.findById(board.getId()).orElseThrow();
+    org.assertj.core.api.Assertions.assertThat(updated.getTitle()).isEqualTo("수정된 제목");
+    org.assertj.core.api.Assertions.assertThat(updated.getNickname()).isEqualTo(email.split("@")[0]);
   }
 
   @Test

--- a/src/test/java/com/modureview/controller/BoardControllerTest.java
+++ b/src/test/java/com/modureview/controller/BoardControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import jakarta.servlet.http.Cookie;
 
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -93,7 +94,6 @@ class BoardControllerTest {
     req.put("title", "악성 스크립트 테스트");
     req.put("content", "<p>정상</p><script>alert('x')</script>");
     req.put("category", "car");
-    req.put("nickname", email.split("@")[0]);
 
     String json = objectMapper.writeValueAsString(req);
 
@@ -102,6 +102,7 @@ class BoardControllerTest {
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/reviews/new")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json)
+                .cookie(new Cookie("userNickname", email.split("@")[0]))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
   }
@@ -118,7 +119,6 @@ class BoardControllerTest {
     req.put("title", "수정 제목");
     req.put("content", "<img src=\"a.png\" onerror=\"alert(1)\"/>");
     req.put("category", "car");
-    req.put("nickname", email.split("@")[0]);
 
     String json = objectMapper.writeValueAsString(req);
 
@@ -127,6 +127,7 @@ class BoardControllerTest {
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/reviews/{boardId}", board.getId())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json)
+                .cookie(new Cookie("userNickname", email.split("@")[0]))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
   }
@@ -144,7 +145,6 @@ class BoardControllerTest {
     req.put("title", "새 게시글 제목");
     req.put("content", "<p>내용</p><img src=\"https://cdn.example.com/uuid-1111.png\"/>");
     req.put("category", "car");
-    req.put("nickname", email.split("@")[0]);
 
     String json = objectMapper.writeValueAsString(req);
 
@@ -153,6 +153,7 @@ class BoardControllerTest {
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/reviews/new")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json)
+                .cookie(new Cookie("userNickname", email.split("@")[0]))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isCreated())
         .andReturn();
@@ -176,7 +177,6 @@ class BoardControllerTest {
     req.put("title", "수정된 제목");
     req.put("content", "<p>수정된 내용</p><img src=\"https://cdn.example.com/uuid-2222.jpg\"/>");
     req.put("category", "car");
-    req.put("nickname", email.split("@")[0]);
 
     String json = objectMapper.writeValueAsString(req);
 
@@ -184,7 +184,8 @@ class BoardControllerTest {
     mockMvc.perform(
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/reviews/{boardId}", board.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
+                .content(json)
+                .cookie(new Cookie("userNickname", email.split("@")[0])))
         .andExpect(status().isNoContent());
 
     // then: DB 반영 확인

--- a/src/test/java/com/modureview/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/modureview/controller/BookmarkControllerTest.java
@@ -8,9 +8,9 @@ import com.modureview.entity.Board;
 import com.modureview.entity.BookMark;
 import com.modureview.entity.User;
 import com.modureview.repository.BoardRepository;
-import com.modureview.repository.BookMarkRepository;
+import com.modureview.repository.BookmarkRepository;
 import com.modureview.repository.UserRepository;
-import com.modureview.service.BookMarkService;
+import com.modureview.service.BookmarkService;
 import com.modureview.utill.TestUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.transaction.Transactional;
@@ -34,92 +34,88 @@ import org.springframework.test.web.servlet.MvcResult;
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("h2")
-class BookMarkControllerTest {
+class BookmarkControllerTest {
 
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @Autowired
-  private BookMarkService bookMarkService;
-
-  @Autowired
-  private BookMarkRepository bookMarkRepository;
-
-  @Autowired
-  private UserRepository userRepository;
-
-  @Autowired
-  private BoardRepository boardRepository;
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private BookmarkService bookmarkService;
+  @Autowired private BookmarkRepository bookmarkRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private BoardRepository boardRepository;
 
   private TestUtil testUtil;
-
+  private Board savedBoard;
+  private User user1;
+  private User user2;
 
   @BeforeEach
   void setUp() {
     this.testUtil = new TestUtil();
-    User user = userRepository.save(testUtil.newUser("test@test.com"));
-    userRepository.save(testUtil.newUser("test1@test.com"));
-    Board board = boardRepository.save(testUtil.newBoard(user));
+    user1 = userRepository.save(testUtil.newUser("test@test.com"));
+    user2 = userRepository.save(testUtil.newUser("test1@test.com"));
+    savedBoard = boardRepository.save(testUtil.newBoard(user1));
+
     List<BookMark> bookMarks = new ArrayList<>();
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 3; i++) {
       bookMarks.add(
           BookMark.builder()
-              .email("test" + i + "@test.com")
-              .boardId(board.getId())
-              .build()
-      );
+              .nickname(user2.getNickname())
+              .boardId(savedBoard.getId())
+              .build());
     }
-    bookMarkRepository.saveAll(bookMarks);
+    bookmarkRepository.saveAll(bookMarks);
   }
 
   @Test
-  @DisplayName("GET /reviews/{reviewId}/bookMarkController - isBookmarked : false")
+  @DisplayName("GET /reviews/{reviewId}/bookmarks - isBookmarked : false")
   void getBookmark_false() throws Exception {
-    Board byAuthorEmail = boardRepository.findByAuthorEmail("test@test.com");
     long startTime = System.nanoTime();
-    MvcResult mvcResult = mockMvc.perform(
-            get("/reviews/{reviewId}/bookmarks", byAuthorEmail.getId())
-                .cookie(new Cookie("email", "test@test.com"))
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andReturn();
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                get("/reviews/{reviewId}/bookmarks", savedBoard.getId())
+                    // no nickname cookie -> defaultValue="null"
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
     long endTime = System.nanoTime();
     long duration = (endTime - startTime);
     double durationMs = duration / 1_100_000.0;
-    log.info("BookMarkControllerTest.getBoardDetail()-false 실행 시간 : {} ns ({} ms)", duration,
+    log.info(
+        "BookmarkControllerTest.getBoardDetail()-false 실행 시간 : {} ns ({} ms)",
+        duration,
         String.format("%.3f", durationMs));
     String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
     Object jsonObject = objectMapper.readValue(responseBody, Object.class);
-    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
-        .writeValueAsString(jsonObject);
+    String prettyJson =
+        objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
     log.info("Formatted JSON Response:");
     log.info("prettyJson == {}", prettyJson);
   }
 
-
   @Test
-  @DisplayName("GET /reviews/{reviewId}/bookMarkController - isBookmarked : true")
+  @DisplayName("GET /reviews/{reviewId}/bookmarks - isBookmarked : true")
   void getBookmark_success() throws Exception {
-    Board byAuthorEmail = boardRepository.findByAuthorEmail("test@test.com");
     long startTime = System.nanoTime();
-    MvcResult mvcResult = mockMvc.perform(
-            get("/reviews/{reviewId}/bookmarks", byAuthorEmail.getId())
-                .cookie(new Cookie("email", "test1@test.com"))
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andReturn();
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                get("/reviews/{reviewId}/bookmarks", savedBoard.getId())
+                    .cookie(new Cookie("userNickname", user2.getNickname()))
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
     long endTime = System.nanoTime();
     long duration = (endTime - startTime);
     double durationMs = duration / 1_100_000.0;
-    log.info("BookMarkControllerTest.getBoardDetail()-true 실행 시간 : {} ns ({} ms)", duration,
+    log.info(
+        "BookmarkControllerTest.getBoardDetail()-true 실행 시간 : {} ns ({} ms)",
+        duration,
         String.format("%.3f", durationMs));
     String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
     Object jsonObject = objectMapper.readValue(responseBody, Object.class);
-    String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
-        .writeValueAsString(jsonObject);
+    String prettyJson =
+        objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
     log.info("Formatted JSON Response:");
     log.info("prettyJson == {}", prettyJson);
   }

--- a/src/test/java/com/modureview/controller/CommentControllerTest.java
+++ b/src/test/java/com/modureview/controller/CommentControllerTest.java
@@ -64,7 +64,9 @@ class CommentControllerTest {
   @Test
   @DisplayName("save comment결과")
   void saveComment() {
-    CommentSaveRequest commentSaveRequest = new CommentSaveRequest("user1@example.com", food,
+    // 사전 준비: 유저 생성 (닉네임=user1)
+    userRepository.save(testUtil.newUser("user1@example.com"));
+    CommentSaveRequest commentSaveRequest = new CommentSaveRequest("user1", food,
         "네네 아이고아이고");
     commentController.addComment(1L, commentSaveRequest);
   }
@@ -72,7 +74,7 @@ class CommentControllerTest {
   @Test
   @DisplayName("delete 결과")
   void deleteComment() {
-    CommentDeleteRequest commentDeleteRequest = new CommentDeleteRequest("user1@example.com",1L,1L);
+    CommentDeleteRequest commentDeleteRequest = new CommentDeleteRequest("user1@example.com",1L);
 
     commentController.deleteComment(1L, commentDeleteRequest);
 
@@ -89,7 +91,7 @@ class CommentControllerTest {
       comments.add(
           Comment.builder()
               .boardId(newBoardId)
-              .userEmail(newBoard.getAuthorEmail())
+              .nickname(newBoard.getNickname())
               .content("test content" + i)
               .createdAt(LocalDateTime.now().minusMinutes(i))
               .build());

--- a/src/test/java/com/modureview/controller/MyPageControllerTest.java
+++ b/src/test/java/com/modureview/controller/MyPageControllerTest.java
@@ -44,27 +44,32 @@ class MyPageControllerTest {
   @Autowired
   private UserRepository userRepository;
 
+  private String targetNickname;
+
   @BeforeEach
   void setUp() {
 
     User newUser = userRepository.save(User.builder()
-        .email("작성자")
+        .email("writer@test.com")
+        .nickname("작성자")
         .build());
     User targetUser = userRepository.save(User.builder()
-        .email("test")
+        .email("target@test.com")
+        .nickname("테스트닉")
         .build());
+    targetNickname = targetUser.getNickname();
 
     List<Board> boards = new ArrayList<>();
     for (int i = 0; i < 30; i++) {
       if (i % 2 != 0) {
         boards.add(
-            Board.builder().title("TestTitle" + i).user(newUser).authorEmail(newUser.getEmail())
+            Board.builder().title("TestTitle" + i).user(newUser).nickname(newUser.getNickname())
                 .content("<p>내용 예시 " + i + "</p>")
                 .commentsCount(ThreadLocalRandom.current().nextInt(1, 101))
                 .bookmarksCount(ThreadLocalRandom.current().nextInt(1, 101)).build());
       } else {
         boards.add(
-            Board.builder().user(targetUser).authorEmail(targetUser.getEmail())
+            Board.builder().user(targetUser).nickname(targetUser.getNickname())
                 .content("<p>내용 예시 " + i + "</p>")
                 .commentsCount(ThreadLocalRandom.current().nextInt(1, 101))
                 .bookmarksCount(ThreadLocalRandom.current().nextInt(1, 101)).build());
@@ -84,7 +89,7 @@ class MyPageControllerTest {
     long startTime = System.currentTimeMillis();
     MvcResult mvcResult = mockMvc.perform(
             get("/users/me/reviews")
-                .cookie(new Cookie("userEmail", "test"))
+                .cookie(new Cookie("userNickname", targetNickname))
                 .param("page", "1")
         )
         .andExpect(status().isOk())

--- a/src/test/java/com/modureview/controller/NotificationControllerTest.java
+++ b/src/test/java/com/modureview/controller/NotificationControllerTest.java
@@ -77,7 +77,7 @@ class NotificationControllerTest {
     board = Board.builder()
         .title("아주아주아주아주긴제목확인용타이틀")
         .user(user)
-        .authorEmail(user.getEmail())
+        .nickname(user.getNickname())
         .category(com.modureview.entity.Category.car)
         .content("<p>content</p>")
         .commentsCount(0)

--- a/src/test/java/com/modureview/controller/SearchControllerTest.java
+++ b/src/test/java/com/modureview/controller/SearchControllerTest.java
@@ -47,7 +47,7 @@ class SearchControllerTest {
       boards.add(
           Board.builder()
               .title("테스트" + i)
-              .authorEmail("작성자" + i)
+              .nickname("작성자" + i)
               .category(Category.car)
               .content("<p>내용 예시 " + i + "<p/>")
               .commentsCount(i + i)
@@ -57,7 +57,7 @@ class SearchControllerTest {
       boards.add(
           Board.builder()
               .title("target_1")
-              .authorEmail("target_1")
+              .nickname("target_1")
               .category(Category.car)
               .content("<p> target_1 <p/>")
               .commentsCount(24)
@@ -68,7 +68,7 @@ class SearchControllerTest {
         boards.add(
             Board.builder()
                 .title("테스트" + i)
-                .authorEmail("작성자" + i)
+                .nickname("작성자" + i)
                 .category(Category.car)
                 .content("<p>내용 예시 " + i + "<p/>")
                 .commentsCount(i + i)
@@ -78,7 +78,7 @@ class SearchControllerTest {
         boards.add(
             Board.builder()
                 .title("target_2")
-                .authorEmail("target_2")
+                .nickname("target_2")
                 .category(Category.car)
                 .content("<p> target_2 <p/>")
                 .commentsCount(22)
@@ -88,7 +88,7 @@ class SearchControllerTest {
         boards.add(
             Board.builder()
                 .title("target_3")
-                .authorEmail("target_4")
+                .nickname("target_4")
                 .category(Category.car)
                 .content("<p> Target_5 <p/>")
                 .commentsCount(22)
@@ -141,7 +141,7 @@ class SearchControllerTest {
             get("/search")
                 .param("keyword", "테스트")
                 .param("page", "1")
-                .param("sort", "hotcomment")
+                .param("sort", "hotcomments")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
@@ -171,7 +171,7 @@ class SearchControllerTest {
             get("/search")
                 .param("keyword", "테스트")
                 .param("page", "2")
-                .param("sort", "hotbookmark")
+                .param("sort", "hotbookmarks")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
@@ -201,7 +201,7 @@ class SearchControllerTest {
             get("/search")
                 .param("keyword", "장충동왕족발보쌈")
                 .param("page", "2")
-                .param("sort", "hotbookmark")
+                .param("sort", "hotbookmarks")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
@@ -223,4 +223,3 @@ class SearchControllerTest {
   }
 
 }
-

--- a/src/test/java/com/modureview/controller/UserReviewsControllerTest.java
+++ b/src/test/java/com/modureview/controller/UserReviewsControllerTest.java
@@ -60,7 +60,7 @@ class UserReviewsControllerTest {
           Board.builder()
               .title("테스트 게시물 " + i)
               .user(testUser)
-              .authorEmail("test@example.com")
+              .nickname(testUser.getNickname())
               .category(Category.car)
               .content("<p>테스트 내용 " + i + "</p>")
               .commentsCount(i * 2)
@@ -74,7 +74,7 @@ class UserReviewsControllerTest {
           Board.builder()
               .title("다른 사용자 게시물 " + i)
               .user(otherUser)
-              .authorEmail("other@example.com")
+              .nickname(otherUser.getNickname())
               .category(Category.food)
               .content("<p>다른 사용자 내용 " + i + "</p>")
               .commentsCount(i * 5)
@@ -93,11 +93,11 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - recent 정렬로 사용자 리뷰 조회 성공")
+  @DisplayName("GET /users/{nickname}/reviews - recent 정렬로 사용자 리뷰 조회 성공")
   void getUserReviews_Success_Recent() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/test@example.com")
+            get("/users/test/reviews")
                 .param("cursor", "0")
                 .param("sort", "recent")
                 .accept(MediaType.APPLICATION_JSON))
@@ -120,13 +120,13 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - hotcomment 정렬로 사용자 리뷰 조회 성공")
+  @DisplayName("GET /users/{nickname}/reviews - hotcomment 정렬로 사용자 리뷰 조회 성공")
   void getUserReviews_Success_HotComment() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/test@example.com")
+            get("/users/test/reviews")
                 .param("cursor", "0")
-                .param("sort", "hotcomment")
+                .param("sort", "hotcomments")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
@@ -148,13 +148,13 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - hotbookmark 정렬로 사용자 리뷰 조회 성공")
+  @DisplayName("GET /users/{nickname}/reviews - hotbookmark 정렬로 사용자 리뷰 조회 성공")
   void getUserReviews_Success_HotBookmark() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/test@example.com")
+            get("/users/test/reviews")
                 .param("cursor", "0")
-                .param("sort", "hotbookmark")
+                .param("sort", "hotbookmarks")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
@@ -176,11 +176,11 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - 존재하지 않는 사용자 이메일로 조회")
+  @DisplayName("GET /users/{nickname}/reviews - 존재하지 않는 사용자 닉네임으로 조회")
   void getUserReviews_Success_NonExistentUser() throws Exception {
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/nonexistent@example.com")
+            get("/users/nonexistent/reviews")
                 .param("cursor", "0")
                 .param("sort", "recent")
                 .accept(MediaType.APPLICATION_JSON))
@@ -204,14 +204,14 @@ class UserReviewsControllerTest {
   }
 
   @Test
-  @DisplayName("GET /users/{memberEmail} - 커서 기반 페이징 테스트")
+  @DisplayName("GET /users/{nickname}/reviews - 커서 기반 페이징 테스트")
   void getUserReviews_Success_CursorPaging() throws Exception {
     List<Board> savedBoards = userReviewsRepository.findAll();
     Long existingBoardId = savedBoards.get(2).getId();
     
     long startTime = System.nanoTime();
     MvcResult mvcResult = mockMvc.perform(
-            get("/users/test@example.com")
+            get("/users/test/reviews")
                 .param("cursor", existingBoardId.toString())
                 .param("sort", "recent")
                 .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/modureview/service/BoardCategoryServiceTest.java
+++ b/src/test/java/com/modureview/service/BoardCategoryServiceTest.java
@@ -40,7 +40,7 @@ class BoardCategoryServiceTest {
       boards.add(
           Board.builder()
               .title("테스트" + i)
-              .authorEmail("작성자" + i)
+              .nickname("작성자" + i)
               .category(Category.car)
               .content("<p>내용 예시 " + i + "<p/>")
               .commentsCount(i + i)
@@ -50,7 +50,7 @@ class BoardCategoryServiceTest {
       boards.add(
           Board.builder()
               .title("target_1")
-              .authorEmail("target_1")
+              .nickname("target_1")
               .category(Category.car)
               .content("<p> target_1 <p/>")
               .commentsCount(24)
@@ -61,7 +61,7 @@ class BoardCategoryServiceTest {
         boards.add(
             Board.builder()
                 .title("테스트" + i)
-                .authorEmail("작성자" + i)
+                .nickname("작성자" + i)
                 .category(Category.car)
                 .content("<p>내용 예시 " + i + "<p/>")
                 .commentsCount(i + i)
@@ -71,7 +71,7 @@ class BoardCategoryServiceTest {
         boards.add(
             Board.builder()
                 .title("target_2")
-                .authorEmail("target_2")
+                .nickname("target_2")
                 .category(Category.car)
                 .content("<p> target_2 <p/>")
                 .commentsCount(22)
@@ -81,7 +81,7 @@ class BoardCategoryServiceTest {
         boards.add(
             Board.builder()
                 .title("target_3")
-                .authorEmail("target_4")
+                .nickname("target_4")
                 .category(Category.car)
                 .content("<p> Target_5 <p/>")
                 .commentsCount(22)
@@ -92,7 +92,7 @@ class BoardCategoryServiceTest {
           boards.add(
               Board.builder()
                   .title("AA테스트AA")
-                  .authorEmail("작성자" + z)
+                  .nickname("작성자" + z)
                   .category(Category.car)
                   .content("<p>내용 예시 " + z + "<p/>")
                   .commentsCount(400)

--- a/src/test/java/com/modureview/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/modureview/service/JwtTokenServiceTest.java
@@ -49,8 +49,8 @@ class JwtTokenServiceTest {
   void loginTokenIssueCheck() {
     List<ResponseCookie> cookies = jwtTokenService.loginTokenIssue("user@domain.com");
 
-    assertThat(cookies).hasSize(3);
+    assertThat(cookies).hasSize(4);
     assertThat(cookies.stream().map(ResponseCookie::getName).toList())
-        .containsExactlyInAnyOrder("accessToken", "refreshToken", "userEmail");
+        .containsExactlyInAnyOrder("accessToken", "refreshToken", "userEmail", "userNickname");
   }
 }

--- a/src/test/java/com/modureview/service/MyPageServiceTest.java
+++ b/src/test/java/com/modureview/service/MyPageServiceTest.java
@@ -43,13 +43,15 @@ class MyPageServiceTest {
   @BeforeEach
   void setUp() {
     User newUser = User.builder()
-        .email("TargetEmail")
+        .email("target@example.com")
+        .nickname("target")
         .build();
 
     User user = userRepository.save(newUser);
 
     User notTargetUser = User.builder()
-        .email("NotTargetEmail")
+        .email("notarget@example.com")
+        .nickname("notarget")
         .build();
 
     User NotTargetUser = userRepository.save(notTargetUser);
@@ -58,13 +60,13 @@ class MyPageServiceTest {
     for (int i = 0; i < 30; i++) {
       if (i % 2 != 0) {
         boards.add(
-            Board.builder().title("TestTitle" + i).user(NotTargetUser).authorEmail("NotTargetEmail")
+            Board.builder().title("TestTitle" + i).user(NotTargetUser).nickname(NotTargetUser.getNickname())
                 .content("<p>내용 예시 " + i + "</p>")
                 .commentsCount(ThreadLocalRandom.current().nextInt(1, 101))
                 .bookmarksCount(ThreadLocalRandom.current().nextInt(1, 101)).build());
       } else {
         boards.add(
-            Board.builder().user(user).authorEmail(newUser.getEmail())
+            Board.builder().user(user).nickname(user.getNickname())
                 .content("<p>내용 예시 " + i + "</p>")
                 .commentsCount(ThreadLocalRandom.current().nextInt(1, 101))
                 .bookmarksCount(ThreadLocalRandom.current().nextInt(1, 101)).build());
@@ -81,7 +83,7 @@ class MyPageServiceTest {
   @Test
   @DisplayName("작성자가 올바른 사람인지 확인")
   void MyPage_success() throws Exception {
-    String email = "TargetEmail";
+    String email = "target";
     int page = 1;
     long startTime = System.nanoTime();
     Page<Board> rep = myPageService.myPageBoard(email, page);
@@ -96,4 +98,3 @@ class MyPageServiceTest {
     log.info("realJson == {}", realJson);
   }
 }
-

--- a/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
+++ b/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
@@ -48,13 +48,13 @@ class MyPageServiceUnitTest {
   @Test
   @DisplayName("존재하지 않는 사용자가 북마크 페이지 조회시 USER_NOT_FOUND 예외 발생")
   void testMyPageBookmark_UserNotFound() {
-    String email = "nouser@example.com";
+    String nickname = "nouser";
     int page = 1;
 
-    when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+    when(userRepository.findByNickname(nickname)).thenReturn(Optional.empty());
 
     CustomException ex = assertThrows(CustomException.class,
-        () -> service.myPageBookmark(email, page));
+        () -> service.myPageBookmark(nickname, page));
 
     log.info("ex.getErrorCode() == {}", ex.getErrorCode());
   }
@@ -62,25 +62,26 @@ class MyPageServiceUnitTest {
   @Test
   @DisplayName("존재하는 사용자가 북마크 페이지 조회 시 정상 결과 반환")
   void testMyPageBookmark_Success() {
-    String email = "user@example.com";
+    String nickname = "user";
     int pageNumber = 1;
     int pageSize = 6;
 
     User newUser = User.builder()
         .email("user@example.com")
+        .nickname(nickname)
         .build();
-    when(userRepository.findByEmail(email)).thenReturn(Optional.of(newUser));
+    when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(newUser));
 
     List<Long> bookmarkIds = List.of(10L, 20L, 30L);
     Pageable pageable = PageRequest.of(pageNumber - 1, pageSize,
         Sort.by(Sort.Direction.DESC, "createdAt"));
     Page<Long> idPage = new PageImpl<>(bookmarkIds, pageable, bookmarkIds.size());
-    when(myPageBookMarkRepository.findBookMarksByNickname(email, pageable))
+    when(myPageBookMarkRepository.findBookMarksByNickname(nickname, pageable))
         .thenReturn(idPage);
 
     Board b1 = Board.builder()
         .title("타이틀1")
-        .authorEmail(email)
+        .nickname(nickname)
         .category(Category.book)
         .content("내용1")
         .commentsCount(0)
@@ -90,7 +91,7 @@ class MyPageServiceUnitTest {
 
     Board b2 = Board.builder()
         .title("타이틀2")
-        .authorEmail(email)
+        .nickname(nickname)
         .category(Category.book)
         .content("내용2")
         .commentsCount(0)
@@ -100,7 +101,7 @@ class MyPageServiceUnitTest {
 
     Board b3 = Board.builder()
         .title("타이틀3")
-        .authorEmail(email)
+        .nickname(nickname)
         .category(Category.book)
         .content("내용3")
         .commentsCount(0)
@@ -111,7 +112,7 @@ class MyPageServiceUnitTest {
     when(myPageRepository.findAllById(bookmarkIds))
         .thenReturn(List.of(b2, b3, b1));
 
-    Page<Board> result = service.myPageBookmark(email, pageNumber);
+    Page<Board> result = service.myPageBookmark(nickname, pageNumber);
 
     List<Long> resultIds = result.getContent().stream()
         .map(Board::getId)

--- a/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
+++ b/src/test/java/com/modureview/service/MyPageServiceUnitTest.java
@@ -75,7 +75,7 @@ class MyPageServiceUnitTest {
     Pageable pageable = PageRequest.of(pageNumber - 1, pageSize,
         Sort.by(Sort.Direction.DESC, "createdAt"));
     Page<Long> idPage = new PageImpl<>(bookmarkIds, pageable, bookmarkIds.size());
-    when(myPageBookMarkRepository.findBookMarksByEmail(email, pageable))
+    when(myPageBookMarkRepository.findBookMarksByNickname(email, pageable))
         .thenReturn(idPage);
 
     Board b1 = Board.builder()

--- a/src/test/java/com/modureview/service/SearchServiceTest.java
+++ b/src/test/java/com/modureview/service/SearchServiceTest.java
@@ -38,7 +38,7 @@ class SearchServiceTest {
       boards.add(
           Board.builder()
               .title("테스트" + i)
-              .authorEmail("작성자" + i)
+              .nickname("작성자" + i)
               .category(Category.car)
               .content("<p>내용 예시 " + i + "<p/>")
               .commentsCount(i + i)
@@ -48,7 +48,7 @@ class SearchServiceTest {
       boards.add(
           Board.builder()
               .title("target_1")
-              .authorEmail("target_1")
+              .nickname("target_1")
               .category(Category.car)
               .content("<p> target_1 <p/>")
               .commentsCount(24)
@@ -59,7 +59,7 @@ class SearchServiceTest {
         boards.add(
             Board.builder()
                 .title("테스트" + i)
-                .authorEmail("작성자" + i)
+                .nickname("작성자" + i)
                 .category(Category.car)
                 .content("<p>내용 예시 " + i + "<p/>")
                 .commentsCount(i + i)
@@ -69,7 +69,7 @@ class SearchServiceTest {
         boards.add(
             Board.builder()
                 .title("target_2")
-                .authorEmail("target_2")
+                .nickname("target_2")
                 .category(Category.car)
                 .content("<p> target_2 <p/>")
                 .commentsCount(22)
@@ -79,7 +79,7 @@ class SearchServiceTest {
         boards.add(
             Board.builder()
                 .title("target_3")
-                .authorEmail("target_4")
+                .nickname("target_4")
                 .category(Category.car)
                 .content("<p> Target_5 <p/>")
                 .commentsCount(22)

--- a/src/test/java/com/modureview/service/UserReviewsServiceTest.java
+++ b/src/test/java/com/modureview/service/UserReviewsServiceTest.java
@@ -47,28 +47,28 @@ class UserReviewsServiceTest {
 		// user1의 게시글들
 		for (int i = 0; i < 5; i++) {
 			boards.add(
-				Board.builder()
-					.title("user1_게시글_" + i)
-					.authorEmail("user1@test.com")
-					.category(Category.book)
-					.content("<p>user1 내용 " + i + "</p>")
-					.commentsCount(i * 3)
-					.bookmarksCount(i * 5)
-					.build()
+            Board.builder()
+                .title("user1_게시글_" + i)
+                .nickname("user1")
+                .category(Category.book)
+                .content("<p>user1 내용 " + i + "</p>")
+                .commentsCount(i * 3)
+                .bookmarksCount(i * 5)
+                .build()
 			);
 		}
 
 		// user2의 게시글들 (구분용)
 		for (int i = 0; i < 3; i++) {
 			boards.add(
-				Board.builder()
-					.title("user2_게시글_" + i)
-					.authorEmail("user2@test.com")
-					.category(Category.car)
-					.content("<p>user2 내용 " + i + "</p>")
-					.commentsCount(i * 2)
-					.bookmarksCount(i * 4)
-					.build()
+            Board.builder()
+                .title("user2_게시글_" + i)
+                .nickname("user2")
+                .category(Category.car)
+                .content("<p>user2 내용 " + i + "</p>")
+                .commentsCount(i * 2)
+                .bookmarksCount(i * 4)
+                .build()
 			);
 		}
 

--- a/src/test/java/com/modureview/unitTest/BoardServiceTest.java
+++ b/src/test/java/com/modureview/unitTest/BoardServiceTest.java
@@ -50,7 +50,7 @@ public class BoardServiceTest {
     <img src="https://cdn.example.com/uuid1-aaaa.jpg" />
     <img src="https://cdn.example.com/uuid2-bbbb.png" />
   """;
-    BoardSaveRequest request = new BoardSaveRequest("제목", html, "car", "testuser@example.com");
+    BoardSaveRequest request = new BoardSaveRequest("제목", html, "car");
 
     // when
     List<String> uuids = boardService.extractImageInfo(request);
@@ -66,11 +66,13 @@ public class BoardServiceTest {
   public void boardSaveTest() {
     // given
     String email = "testuser@example.com";
+    String nickname = "testuser";
     User mockUser = User.builder()
         .email(email)
+        .nickname(nickname)
         .build();
 
-    when(userRepository.findByEmail(email)).thenReturn(Optional.of(mockUser));
+    when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(mockUser));
 
     String html = """
         <p>본문입니다</p>
@@ -81,13 +83,12 @@ public class BoardServiceTest {
     BoardSaveRequest request = new BoardSaveRequest(
         "테스트 제목",
         html,
-        "car",
-        email
+        "car"
     );
 
     // when
     List<String> uuids = boardService.extractImageInfo(request);
-    boardService.saveBoard(request, uuids);
+    boardService.saveBoard(request, nickname, uuids);
 
     // then
     ArgumentCaptor<Board> captor = ArgumentCaptor.forClass(Board.class);
@@ -97,7 +98,7 @@ public class BoardServiceTest {
 
     assertEquals("테스트 제목", savedBoard.getTitle());
     assertEquals(Category.car, savedBoard.getCategory());
-    assertEquals(email, savedBoard.getAuthorEmail());
+    assertEquals(nickname, savedBoard.getNickname());
 
     List<BoardImage> images = savedBoard.getImages();
     assertEquals(2, images.size());

--- a/src/test/java/com/modureview/utill/TestUtil.java
+++ b/src/test/java/com/modureview/utill/TestUtil.java
@@ -9,6 +9,7 @@ public class TestUtil {
   public User newUser(String email) {
     return User.builder()
         .email(email)
+        .nickname(email.contains("@") ? email.substring(0, email.indexOf('@')) : email)
         .build();
   }
 
@@ -16,7 +17,7 @@ public class TestUtil {
     return Board.builder()
         .title("테스트")
         .user(newUser)
-        .authorEmail(newUser.getEmail())
+        .nickname(newUser.getNickname())
         .category(Category.car)
         .content("<p>내용 예시</p>")
         .commentsCount(10)


### PR DESCRIPTION
## 👀제목  
UserReviews 리팩토링 (닉네임 기반 조회 전환 및 리포지토리/서비스 개선)  

## 🙋변경 사항  
- `SecurityConfig`, `JwtAuthFilter`에서 `/users/*/reviews` 엔드포인트 접근 허용 추가  
- `UserReviewsRepository` 쿼리 메서드 구조 변경: `authorEmail` 기반 조회 → `nickname` 기반 조회로 전환  
- 기존 `findByAuthorEmailByCreatedAt`, `findByAuthorEmailByBookmarksCount`, `findByAuthorEmailByCommentsCount` 메서드 리팩토링 및 `nickname` 기반 메서드 추가  
- `UserReviewsService`에서 페이징 및 정렬 로직 개선: `recent`, `hotbookmark`, `hotcomment` 정렬 시 `nickname` 기준 조회  
- `UserReviewsService`에 `countByNickname` 메서드 추가  
- 테스트 코드(UserReviewsControllerTest, UserReviewsServiceTest) 전반적으로 `authorEmail` → `nickname` 기반으로 수정  

## 💎설명  
이번 리팩토링은 사용자 리뷰(UserReviews) 조회 API를 **이메일 기반**에서 **닉네임 기반**으로 전환한 작업입니다【63†source】.  
기존에는 사용자 식별 시 이메일을 사용했으나, 최근 리팩토링 흐름(User, Bookmark, Comment, Search, MyPage)과 일관성을 맞추기 위해 닉네임을 기준으로 변경했습니다.  
또한 Service 단에서 페이징 및 정렬 로직을 개선하여 첫 페이지와 커서 기반 페이지네이션이 분리된 구조를 단순화했습니다.  
테스트 코드 역시 닉네임 기반으로 전환되었으며, API 요청 경로(`/users/{nickname}/reviews`) 및 정렬 파라미터명(`hotcomment`, `hotbookmark`)이 일관되게 반영되었습니다.  

## 🔨테스트 방법  
1. `GET /users/{nickname}/reviews?sort=recent&cursor=0` 요청 시 최신순 정렬 결과가 정상 반환되는지 확인  
2. `GET /users/{nickname}/reviews?sort=hotcomment` 요청 시 댓글 수 기준 내림차순 정렬이 적용되는지 검증  
3. `GET /users/{nickname}/reviews?sort=hotbookmark` 요청 시 북마크 수 기준 내림차순 정렬이 적용되는지 검증  
4. 커서 기반 페이징(`cursor` 파라미터) 요청 시 다음 페이지 데이터가 정상적으로 이어지는지 확인  
5. UserReviewsControllerTest, UserReviewsServiceTest 실행 시 모든 케이스가 성공하는지 확인  

## ⚙성능  
- 불필요한 이메일 기반 조건 제거로 쿼리 단순화  
- `nickname` 기반 인덱스 최적화 가능성 확보 → 조회 효율성 향상  

## ℹ️추가 정보  
- 본 변경으로 User → Bookmark → Comment → Search → MyPage → UserReviews까지 전 기능에서 **닉네임 기반 식별 일관성**이 완성됨  
- 추후 JWT 등 인증 수단과의 연계 시에도 닉네임 기반 구조 유지 가능  

## ❌이슈  
- 없음