### PR TITLE
Refactor/best review response,notificaion test

### DIFF
--- a/src/main/java/com/modureview/controller/LoginController.java
+++ b/src/main/java/com/modureview/controller/LoginController.java
@@ -62,7 +62,8 @@ public class LoginController {
 			Arrays.stream(cookies).forEach(cookie -> {
 				if (cookie.getName().equals("accessToken") ||
 					cookie.getName().equals("refreshToken") ||
-					cookie.getName().equals("userEmail")) {
+					cookie.getName().equals("userEmail") ||
+					cookie.getName().equals("userNickname")) {
 					ResponseCookie expiredCookie = jwtTokenService.expireCookie(
 						ResponseCookie.from(cookie.getName(), "").build()
 					);

--- a/src/main/java/com/modureview/dto/response/BestReviewResponse.java
+++ b/src/main/java/com/modureview/dto/response/BestReviewResponse.java
@@ -9,8 +9,7 @@ public record BestReviewResponse(
 
     Long board_id,
     String title,
-    String author_id,
-    String author_email,
+    String author_nickname,
     String category,
     String preview,
     int comments_count,
@@ -30,8 +29,7 @@ public record BestReviewResponse(
     return new BestReviewResponse(
         board.getId(),
         board.getTitle(),
-        board.getAuthorEmail().split("@")[0],
-        board.getAuthorEmail(),
+        board.getNickname(),
         board.getCategory().name(),
         board.getPreview(),
         board.getCommentsCount(),

--- a/src/main/java/com/modureview/service/JwtTokenService.java
+++ b/src/main/java/com/modureview/service/JwtTokenService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@lombok.RequiredArgsConstructor
 public class JwtTokenService {
 
   @Value("${jwt.secret}")
@@ -34,12 +35,18 @@ public class JwtTokenService {
   }
   private final Long accessTokenExpire = 60 * 60L;
   private final Long refreshTokenExpire = 30 * 24 * 60 * 60L;
+  private final com.modureview.repository.UserRepository userRepository;
 
   public List<ResponseCookie> loginTokenIssue(String userEmail) {
+    String nickname = userRepository.findByEmail(userEmail)
+        .map(com.modureview.entity.User::getNickname)
+        .orElse("익명");
+
     return List.of(
         createAccessToken(userEmail),
         createRefreshToken(userEmail),
-        createUserEmailCookie(userEmail)
+        createUserEmailCookie(userEmail),
+        createNicknameCookie(nickname)
     );
   }
 
@@ -55,6 +62,11 @@ public class JwtTokenService {
 
   public ResponseCookie createUserEmailCookie(String userEmail) {
     return createCookie("userEmail", userEmail, refreshTokenExpire, true);
+  }
+
+  public ResponseCookie createNicknameCookie(String nickname) {
+    // nickname may contain non-ASCII (e.g., Korean); ensure cookie-safe value
+    return createCookie("userNickname", nickname, refreshTokenExpire, false);
   }
 
   public void validateToken(String token) {
@@ -91,7 +103,18 @@ public class JwtTokenService {
   }
 
   private ResponseCookie createCookie(String name, String value, long maxAge, boolean httpOnly) {
-    return ResponseCookie.from(name, value)
+    String safeValue = value;
+    // RFC6265 allows only US-ASCII in cookie value; encode when non-ASCII is present
+    if (!isAscii(value)) {
+      try {
+        safeValue = java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        // Fallback to empty if encoding somehow fails
+        safeValue = "";
+      }
+    }
+
+    return ResponseCookie.from(name, safeValue)
         .httpOnly(httpOnly)
         .secure(true)
         .sameSite("LAX")
@@ -99,6 +122,13 @@ public class JwtTokenService {
         .maxAge(maxAge)
         .domain(".modu-review.com")
         .build();
+  }
+
+  private boolean isAscii(String s) {
+    for (int i = 0; i < s.length(); i++) {
+      if (s.charAt(i) > 0x7F) return false;
+    }
+    return true;
   }
 
   public Optional<String> extractCookie(HttpServletRequest request, String cookieName) {
@@ -131,4 +161,3 @@ public class JwtTokenService {
         .build();
   }
 }
-

--- a/src/test/java/com/modureview/controller/NotificationControllerTest.java
+++ b/src/test/java/com/modureview/controller/NotificationControllerTest.java
@@ -77,7 +77,7 @@ class NotificationControllerTest {
     board = Board.builder()
         .title("아주아주아주아주긴제목확인용타이틀")
         .user(user)
-        .authorEmail(user.getEmail())
+        .nickname(user.getNickname())
         .category(com.modureview.entity.Category.car)
         .content("<p>content</p>")
         .commentsCount(0)

--- a/src/test/java/com/modureview/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/modureview/service/JwtTokenServiceTest.java
@@ -49,8 +49,8 @@ class JwtTokenServiceTest {
   void loginTokenIssueCheck() {
     List<ResponseCookie> cookies = jwtTokenService.loginTokenIssue("user@domain.com");
 
-    assertThat(cookies).hasSize(3);
+    assertThat(cookies).hasSize(4);
     assertThat(cookies.stream().map(ResponseCookie::getName).toList())
-        .containsExactlyInAnyOrder("accessToken", "refreshToken", "userEmail");
+        .containsExactlyInAnyOrder("accessToken", "refreshToken", "userEmail", "userNickname");
   }
 }


### PR DESCRIPTION
## 👀제목  
BestReviewResponse 및 Notification 관련 리팩토링 (닉네임 기반 전환 & JWT 쿠키 개선)  

## 🙋변경 사항  
- **LoginController**: 로그아웃 시 만료 처리 대상 쿠키를 `userEmail` → `userNickname`으로 교체  
- **BestReviewResponse DTO**: 작성자 정보 필드 변경 → `author_id`, `author_email` 제거, `author_nickname`으로 단일화  
- **JwtTokenService**:  
  - 로그인 시 `nickname` 쿠키를 함께 발급 (`createNicknameCookie`)  
  - 쿠키 값이 비ASCII 문자(예: 한글)일 경우 안전하게 URL 인코딩 처리  
  - 쿠키 생성 로직에 `isAscii` 검사 및 예외 처리 추가  
- **NotificationControllerTest**: `Board` 엔티티 작성자 식별자 → `authorEmail` → `nickname`으로 수정  
- **JwtTokenServiceTest**: 로그인 토큰 발급 시 생성되는 쿠키 개수 3개 → 4개(`userNickname` 포함)로 수정  

## 💎설명  
이번 리팩토링은 **BestReviewResponse 응답 구조와 JWT 기반 로그인 쿠키 처리 로직을 개선**하는 작업입니다【71†source】.  

- BestReviewResponse의 작성자 정보를 이메일 기반에서 닉네임 기반으로 단일화하여, 리뷰 및 사용자 표시의 일관성을 높였습니다.  
- JwtTokenService에서는 로그인 시 `accessToken`, `refreshToken`, `userEmail` 쿠키 외에 `userNickname` 쿠키를 추가로 발급합니다.  
- RFC6265 쿠키 사양에 맞춰 ASCII 외 문자(예: 한글 닉네임)를 URL 인코딩 처리해 안전하게 브라우저 쿠키에 저장할 수 있도록 개선했습니다.  
- Notification 테스트와 BestReviewResponse 응답 DTO는 모두 닉네임 기반 구조에 맞게 수정되었습니다.  

## 🔨테스트 방법  
1. 로그인 요청 시 발급되는 쿠키 목록이 `accessToken`, `refreshToken`, `userEmail`, `userNickname` 총 4개인지 확인  
2. 닉네임에 한글/특수문자가 포함된 계정으로 로그인 후, 쿠키 값이 URL 인코딩된 안전한 문자열로 저장되는지 확인  
3. `BestReviewResponse` 응답에서 작성자 정보가 `author_nickname`으로만 제공되는지 검증  
4. 로그아웃 요청 시 `userNickname` 쿠키가 만료 처리되는지 확인  
5. JwtTokenServiceTest, NotificationControllerTest 실행 시 정상 통과 여부 확인  

## ⚙성능  
- 쿠키 인코딩 처리 추가로 미미한 오버헤드 발생 가능성 있으나, 브라우저 호환성과 안정성이 크게 향상됨  
- 닉네임 기반 전환으로 도메인 전반의 식별자 구조 단순화  

## ℹ️추가 정보  
- 이번 변경은 User → Bookmark → Comment → Search → MyPage → UserReviews 흐름에 이어, **BestReviewResponse 및 인증/알림 영역까지 닉네임 기반 구조를 확장**한 단계입니다.  
- JWT 쿠키 처리 로직은 추후 OAuth 연동, 멀티 디바이스 로그인 관리에도 그대로 활용 가능  

## ❌이슈  
- 없음