### PR TITLE
Feature(알람기능)::Notification SSE 및 RESTAPI 구현입니다.

### DIFF
--- a/src/main/java/com/modureview/controller/NotificationController.java
+++ b/src/main/java/com/modureview/controller/NotificationController.java
@@ -75,7 +75,7 @@ public class NotificationController {
 		Long userId = userService.findUserId(userEmail);
 
 		boolean read = request.isRead();
-		boolean delete = request.isDelete();
+		boolean delete = request.isDeleted();
 
 
 		if (read == delete ){

--- a/src/main/java/com/modureview/controller/NotificationSseController.java
+++ b/src/main/java/com/modureview/controller/NotificationSseController.java
@@ -1,0 +1,106 @@
+package com.modureview.controller;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.modureview.dto.response.MetaDto;
+import com.modureview.enums.errors.TokenErrorCode;
+import com.modureview.exception.CustomException;
+import com.modureview.service.NotificationService;
+import com.modureview.service.NotificationSseService;
+import com.modureview.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationSseController {
+	private final NotificationSseService sseService;
+	private final NotificationService notificationService;
+	private final UserService userService;
+
+	private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+	@GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter stream(
+		@CookieValue("userNickname") String userNickname,
+		HttpServletResponse response
+	) {
+		if (userNickname == null || userNickname.isEmpty()) {
+			String now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+				.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+			throw new CustomException(TokenErrorCode.NICKNAME_NOT_FOUND, now);
+		}
+
+		// SSE 친화적 헤더
+		response.setHeader("Cache-Control", "no-cache");
+		response.setHeader("X-Accel-Buffering", "no");
+
+		Long userId = userService.findUserIdByNickname(userNickname);
+		log.info("SSE stream request for userId : {}", userId);
+
+		// 명시적 타임아웃 (30분)
+		long timeoutMs = 30 * 60 * 1000L;
+		log.info("Creating SseEmitter for userId: {}", userId);
+
+		SseEmitter emitter = sseService.createSseEmitter(userId, timeoutMs);
+		log.info("SseEmitter created for userId: {}. Emitter: {}", userId, emitter);
+
+		boolean hasUnread = notificationService.hasUnread(userId);
+		log.info("Unread status for userId: {} is {}", userId, hasUnread);
+
+
+		// 초기 meta 이벤트는 1회만, 약간의 지연 후 전송 (전송 성공 여부 로깅)
+		scheduler.schedule(() -> {
+			boolean ok = sseService.sendMeta(userId, new MetaDto(hasUnread));
+			if (ok) {
+				log.info("Initial 'meta' event delivered for userId: {}", userId);
+			} else {
+				log.info("Initial 'meta' event NOT delivered (no active emitters) for userId: {}", userId);
+			}
+		}, 150, TimeUnit.MILLISECONDS);
+
+		// Heartbeat (핑)
+		ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(
+			() -> {
+				boolean ok = sseService.sendPing(userId);
+				if (!ok) {
+					log.debug("No active emitters for ping. userId: {}", userId);
+				}
+			},
+			20, 20, TimeUnit.SECONDS
+		);
+
+		emitter.onCompletion(() -> {
+			log.debug("Emitter completed. userId: {}", userId);
+			future.cancel(false);
+		});
+		emitter.onTimeout(() -> {
+			log.debug("Emitter timeout. userId: {}", userId);
+			future.cancel(false);
+		});
+		emitter.onError(e -> {
+			log.debug("Emitter error. userId: {}, cause: {}", userId, e.toString
+				());
+			future.cancel(false);
+		});
+
+		return emitter;
+	}
+}

--- a/src/main/java/com/modureview/dto/request/NotificationRequest.java
+++ b/src/main/java/com/modureview/dto/request/NotificationRequest.java
@@ -2,6 +2,6 @@ package com.modureview.dto.request;
 
 public record NotificationRequest(
 	boolean isRead,
-	boolean isDelete
+	boolean isDeleted
 ) {
 }

--- a/src/main/java/com/modureview/dto/response/MetaDto.java
+++ b/src/main/java/com/modureview/dto/response/MetaDto.java
@@ -1,0 +1,4 @@
+package com.modureview.dto.response;
+
+public record MetaDto(boolean hasNotification) {
+}

--- a/src/main/java/com/modureview/enums/errors/TokenErrorCode.java
+++ b/src/main/java/com/modureview/enums/errors/TokenErrorCode.java
@@ -1,0 +1,34 @@
+package com.modureview.enums.errors;
+
+import org.springframework.http.HttpStatus;
+
+import com.modureview.enums.ErrorCode;
+
+public enum TokenErrorCode implements ErrorCode {
+	NICKNAME_NOT_FOUND("NICKNAME_NOT_FOUND", HttpStatus.NOT_FOUND, "닉네임을 찾을 수 없습니다. 발생 시각  : %s");
+
+	private final String title;
+	private final HttpStatus httpStatus;
+	private final String detail;
+
+	TokenErrorCode(String title , HttpStatus httpStatus, String detail) {
+		this.title = title;
+		this.httpStatus = httpStatus;
+		this.detail = detail;
+	}
+
+	@Override
+	public String getTitle() {
+		return title;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getDetail() {
+		return detail;
+	}
+}

--- a/src/main/java/com/modureview/infra/NotificationEmitterRegistry.java
+++ b/src/main/java/com/modureview/infra/NotificationEmitterRegistry.java
@@ -1,0 +1,75 @@
+package com.modureview.infra;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class NotificationEmitterRegistry {
+	private final Map<Long, CopyOnWriteArrayList<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter register(Long userId , long timeoutMs){
+        SseEmitter emitter = new SseEmitter(timeoutMs);
+        emitters.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+        emitter.onCompletion(() -> remove(userId, emitter));
+        emitter.onTimeout(() -> remove(userId, emitter));
+        emitter.onError((e)->{
+            log.debug("NotificationEmitterRegistry :: register :: SSE emitter 에러입니다. userId = {} . cause = {} ", userId, e.toString());
+            remove(userId , emitter);
+        });
+        return emitter;
+    }
+
+	public void remove(Long userId, SseEmitter emitter){
+		List<SseEmitter> list = emitters.get(userId);
+		if(list != null){
+			list.remove(emitter);
+			if(list.isEmpty()){
+				emitters.remove(userId);
+			}
+		}
+	}
+
+    public boolean send(Long userId,String eventName , Object data){
+        List<SseEmitter> list = emitters.get(userId);
+        if(list == null || list.isEmpty()) return false;
+
+        boolean delivered = false;
+
+        for(SseEmitter emitter : List.copyOf(list)){
+            try{
+                emitter.send(SseEmitter.event().name(eventName).data(data));
+                delivered = true;
+                log.debug("NotificationEmitterRegistry :: send :: sent. userId={} , event={} , emitter={}", userId, eventName, emitter);
+            }catch(Exception e){
+                log.debug("NotificationEmitterRegistry :: send :: 발송 오류입니다. userId = {} , event = {} , cause = {} ", userId, eventName,e.toString());
+                remove(userId,emitter);
+            }
+        }
+        return delivered;
+    }
+
+    public boolean sendPing(Long userId){
+        List<SseEmitter> list = emitters.get(userId);
+        if(list == null || list.isEmpty()) return false;
+        boolean delivered = false;
+        for(SseEmitter emitter : List.copyOf(list)){
+            try{
+                emitter.send(SseEmitter.event().name("ping").comment("keep-alive"));
+                delivered = true;
+                log.debug("NotificationEmitterRegistry :: sendPing :: sent. userId={} , emitter={}", userId, emitter);
+            } catch(Exception e){
+                log.debug("NotificationEmitterRegistry :: sendPing :: 핑 발송 오류입니다. userId = {} . cause = {} ", userId, e.toString());
+                remove(userId,emitter);
+            }
+        }
+        return delivered;
+    }
+}

--- a/src/main/java/com/modureview/service/NotificationService.java
+++ b/src/main/java/com/modureview/service/NotificationService.java
@@ -40,6 +40,8 @@ public class NotificationService {
 	@Transactional
 	public NotificationPushResponse sendNotification(Long receiverUserId,Long senderUserId,Long boardId,
 		NotificationType type) {
+		log.debug("Create notification: receiver={}, sender={}, board={}, type={}",
+			receiverUserId, senderUserId, boardId, type);
 		userRepository.findById(receiverUserId).orElseThrow(
 			() -> new CustomException(UserErrorCode.USER_NOT_FOUND)
 		);
@@ -50,6 +52,7 @@ public class NotificationService {
 			.notificationType(type)
 			.build();
 		notificationRepository.save(notification);
+		log.info("Notification persisted: id={}", notification.getId());
 		Board targetBoard = boardRepository.findById(boardId)
 			.orElseThrow(() -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND));
 		return NotificationPushResponse.from(notification, targetBoard.getTitle());

--- a/src/main/java/com/modureview/service/NotificationSseService.java
+++ b/src/main/java/com/modureview/service/NotificationSseService.java
@@ -1,0 +1,41 @@
+package com.modureview.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.modureview.dto.response.MetaDto;
+import com.modureview.dto.response.NotificationPushResponse;
+import com.modureview.infra.NotificationEmitterRegistry;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationSseService {
+	private final NotificationEmitterRegistry emitterRegistry;
+
+	public SseEmitter createSseEmitter(Long userId,long timeoutMs){
+		return emitterRegistry.register(userId, timeoutMs);
+	}
+
+    public boolean sendMeta(Long userId, MetaDto meta){
+        boolean ok = emitterRegistry.send(userId, "meta", meta);
+        log.debug("NotificationSseService :: sendMeta :: userId={} , delivered={}", userId, ok);
+        return ok;
+    }
+
+    public boolean sendNotification(Long userId , NotificationPushResponse payload){
+        boolean ok = emitterRegistry.send(userId, "notification", payload);
+        log.debug("NotificationSseService :: sendNotification :: userId={} , notificationId={} , delivered={}",
+            userId, payload.id(), ok);
+        return ok;
+    }
+
+    public boolean sendPing(Long userId){
+        boolean ok = emitterRegistry.sendPing(userId);
+        log.debug("NotificationSseService :: sendPing :: userId={} , delivered={}", userId, ok);
+        return ok;
+    }
+}

--- a/src/test/java/com/modureview/sse/NotificationSseFullIntegrationTest.java
+++ b/src/test/java/com/modureview/sse/NotificationSseFullIntegrationTest.java
@@ -1,0 +1,148 @@
+package com.modureview.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modureview.dto.response.MetaDto;
+import com.modureview.dto.response.NotificationPushResponse;
+import com.modureview.entity.User;
+import com.modureview.repository.UserRepository;
+import com.modureview.service.JwtTokenService;
+import com.modureview.service.NotificationSseService;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("h2")
+class NotificationSseFullIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    JwtTokenService jwtTokenService;
+
+    @Autowired
+    NotificationSseService sseService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        // 테스트 유저 저장
+        testUser = User.builder()
+            .email("test@example.com")
+            .nickname("tester_nick")
+            .build();
+        userRepository.save(testUser);
+    }
+
+    @Test
+    void sse_stream_end_to_end() throws JsonProcessingException {
+        // given
+        ResponseCookie at = jwtTokenService.createAccessToken(testUser.getEmail());
+        String accessToken = at.getValue();
+        String url = "http://localhost:" + port + "/notifications/stream";
+        
+        // 동시성 문제를 해결하기 위해 스레드 안전한 리스트 사용
+        List<String> receivedData = new CopyOnWriteArrayList<>();
+        List<String> receivedEvents = new CopyOnWriteArrayList<>();
+
+        // when
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(Duration.ofSeconds(10))
+            .header("Cookie", "userNickname=" + testUser.getNickname() + "; accessToken=" + accessToken)
+            .GET()
+            .build();
+
+        // 비동기적으로 SSE 스트림을 읽을 스레드 실행
+        Thread readerThread = new Thread(() -> {
+            try {
+                HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.body()))) {
+                    String line;
+                    while ((line = reader.readLine()) != null && !Thread.currentThread().isInterrupted()) {
+                        if (line.startsWith("event:")) {
+                            receivedEvents.add(line.substring(6).trim());
+                        } else if (line.startsWith("data:")) {
+                            receivedData.add(line.substring(5).trim());
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                if (!(e instanceof InterruptedException)) {
+                    e.printStackTrace();
+                }
+            }
+        });
+        readerThread.setDaemon(true);
+        readerThread.start();
+
+        // then
+        // 1. SSE 연결이 성공하고 첫 'meta' 이벤트가 수신될 때까지 대기
+        await().atMost(5, TimeUnit.SECONDS).until(() -> receivedEvents.size() >= 1);
+
+        assertThat(receivedEvents.get(0)).isEqualTo("meta");
+
+        // meta 이벤트의 데이터를 MetaDto로 파싱하여 검증
+        String metaJson = receivedData.get(0);
+        MetaDto metaDto = objectMapper.readValue(metaJson, MetaDto.class);
+        assertThat(metaDto.hasNotification()).isFalse();
+
+        // 2. 서버에서 알림을 보내고 클라이언트가 두 번째 이벤트를 수신하는지 검증
+        NotificationPushResponse payload = new NotificationPushResponse(
+            1000L, 10L, "COMMENT", "Test Title", false, false, LocalDateTime.now()
+        );
+        sseService.sendNotification(testUser.getId(), payload);
+
+        // 'notification' 이벤트가 수신될 때까지 대기 (총 이벤트 수가 2개가 될 때까지)
+        await().atMost(5, TimeUnit.SECONDS).until(() -> receivedEvents.size() >= 2);
+
+        assertThat(receivedEvents.get(1)).isEqualTo("notification");
+        
+        // 3. 수신된 알림 데이터 검증
+        try {
+            String notificationJson = receivedData.get(1);
+
+            // LocalDateTime 파싱 오류를 피하기 위해, JSON 문자열 자체를 검증합니다.
+            assertThat(notificationJson).contains("\"board_id\":" + payload.board_id());
+            assertThat(notificationJson).contains("\"type\":\"" + payload.type() + "\"");
+            assertThat(notificationJson).contains("\"title\":\"" + payload.title() + "\"");
+
+        } catch (Exception e) {
+            fail("Failed to parse notification event data", e);
+        } finally {
+            // 테스트 종료 후 스레드 정리
+            readerThread.interrupt();
+        }
+    }
+}

--- a/src/test/java/com/modureview/sse/NotificationSseIntegrationTest.java
+++ b/src/test/java/com/modureview/sse/NotificationSseIntegrationTest.java
@@ -1,0 +1,143 @@
+package com.modureview.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.modureview.dto.response.NotificationPushResponse;
+import com.modureview.service.NotificationService;
+import com.modureview.service.NotificationSseService;
+import com.modureview.service.UserService;
+import com.modureview.service.JwtTokenService;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+    "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL",
+    "spring.datasource.driverClassName=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.hibernate.ddl-auto=none",
+    "spring.jpa.show-sql=false"
+})
+class NotificationSseIntegrationTest {
+
+  @LocalServerPort
+  int port;
+
+  @Autowired
+  NotificationSseService sseService;
+
+  @MockBean
+  JwtTokenService jwtTokenService;
+
+  @MockBean
+  UserService userService;
+
+  @MockBean
+  NotificationService notificationService;
+
+  @BeforeEach
+  void setUpMocks() {
+    // 모든 요청에서 accessToken 쿠키가 있다고 가정하고 유효성 통과
+    when(jwtTokenService.extractCookie(any(), eq("accessToken")))
+        .thenReturn(Optional.of("dummy"));
+    Mockito.doNothing().when(jwtTokenService).validateToken("dummy");
+
+    // userNickname 쿠키 → 사용자 ID 매핑 (컨트롤러 요구사항과 일치)
+    when(userService.findUserIdByNickname(any(String.class))).thenReturn(1L);
+
+    // 초기 메타: 안읽은 알림 없음
+    when(notificationService.hasUnread(1L)).thenReturn(false);
+  }
+
+  @Test
+  void sse_stream_sends_meta_and_notification_event() throws Exception {
+    String url = "http://localhost:" + port + "/notifications/stream";
+
+    HttpClient client = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build();
+
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .timeout(Duration.ofSeconds(10))
+        .header("Cookie", "userNickname=tester_nick; accessToken=dummy")
+        .GET()
+        .build();
+
+    HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+    assertThat(response.statusCode()).isEqualTo(200);
+    // Content-Type 은 text/event-stream 이어야 함 (부가 파라미터 무시)
+    assertThat(response.headers().firstValue("Content-Type").orElse(""))
+        .contains("text/event-stream");
+
+    BufferedReader reader = new BufferedReader(new InputStreamReader(response.body()));
+
+    // 1) 연결 직후 meta 이벤트 대기
+    CountDownLatch metaLatch = new CountDownLatch(1);
+    Thread metaThread = new Thread(() -> {
+      try {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          if (line.startsWith("event: meta")) {
+            metaLatch.countDown();
+            break;
+          }
+        }
+      } catch (Exception ignored) { }
+    });
+    metaThread.setDaemon(true);
+    metaThread.start();
+
+    boolean metaOk = metaLatch.await(3, TimeUnit.SECONDS);
+    assertThat(metaOk).as("should receive initial meta event").isTrue();
+
+    // 2) 서버에서 notification 이벤트 발행 후 수신 대기
+    CountDownLatch notiLatch = new CountDownLatch(1);
+    Thread notiThread = new Thread(() -> {
+      try {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          if (line.startsWith("event: notification")) {
+            notiLatch.countDown();
+            break;
+          }
+        }
+      } catch (Exception ignored) { }
+    });
+    notiThread.setDaemon(true);
+    notiThread.start();
+
+    // 약간의 지연 후 서버 푸시 트리거
+    Thread.sleep(200);
+    NotificationPushResponse payload = new NotificationPushResponse(
+        999L, 123L, "COMMENT", "Test Title", false, false, LocalDateTime.now()
+    );
+    sseService.sendNotification(1L, payload);
+
+    boolean notiOk = notiLatch.await(3, TimeUnit.SECONDS);
+    assertThat(notiOk).as("should receive notification event after server publish").isTrue();
+
+    // 정리
+    try { reader.close(); } catch (Exception ignored) {}
+  }
+}


### PR DESCRIPTION
## 👀제목  
알림 기능 추가: Notification **SSE 스트리밍** & REST API 개선  

## 🙋변경 사항  
- **NotificationSseController** 신규 도입: `GET /notifications/stream` (SSE)
  - `@CookieValue("userNickname")` 기반 사용자 식별
  - 헤더 설정: `Cache-Control: no-cache`, `X-Accel-Buffering: no`
  - 초기 `meta` 이벤트 지연 전송(≈150ms), **하트비트(핑) 20초 주기**
  - `SseEmitter` 타임아웃 **30분** 및 completion/timeout/error 핸들러 등록
- **NotificationEmitterRegistry**: 다중 `SseEmitter` 관리(등록/제거/전송/핑)
- **NotificationSseService**: SSE 전송 유틸 (`sendMeta`, `sendNotification`, `sendPing`)
- **DTO/에러/요청**
  - `MetaDto(boolean hasNotification)` 추가 (초기 메타 이벤트 페이로드)
  - `NotificationRequest` 필드명: `isDelete` → **`isDeleted`**
  - `TokenErrorCode.NICKNAME_NOT_FOUND` 추가 (닉네임 누락 시 ISO 시각 포함 메시지)
- **NotificationService**: 저장/푸시 로깅 강화 및 응답 생성 흐름 정리
- **테스트 추가**
  - `NotificationSseFullIntegrationTest` (E2E)  
  - `NotificationSseIntegrationTest` (Mock 기반)

## 💎설명  
브라우저와 서버 간 **실시간 알림 전달**을 위해 SSE(Stream) 기반 알림 채널을 구현했습니다.  
접속 시점에 사용자의 **읽지 않은 알림 존재 여부**를 `meta` 이벤트로 1회 전송하고, 이후 서버에서 알림 발생 시 `notification` 이벤트를 push 합니다. 장시간 연결 안정성을 위해 **20초 핑**을 보내며, 클라이언트/네트워크 단절을 감지하면 emitter를 정리합니다.  
닉네임 쿠키가 없을 경우 `TokenErrorCode.NICKNAME_NOT_FOUND` 예외를 발생시키며, 오류 메시지에 **Asia/Seoul 기준 ISO-8601 시각**을 포함하도록 했습니다.  

## 🔨테스트 방법  
1. **메타 이벤트 수신**  
   - `Cookie: userNickname=<닉네임>; accessToken=<토큰>`을 포함하여 `GET /notifications/stream` 연결  
   - 최초 이벤트로 `event: meta` 및 `data: {"hasNotification": false|true}` 수신 확인  
2. **알림 이벤트 수신**  
   - 서버 측에서 `NotificationSseService.sendNotification(userId, payload)` 호출  
   - 클라이언트에서 `event: notification` 수신 및 페이로드(JSON) 필드 검증  
3. **핑(keep-alive) 확인**  
   - 연결 유지 중 주기적으로 `event: ping` 수신 확인  
4. **예외 케이스**  
   - `userNickname` 미포함 요청 시 `NICKNAME_NOT_FOUND` 에러 응답/로그 확인  
5. **통합 테스트 실행**  
   - `NotificationSseFullIntegrationTest`, `NotificationSseIntegrationTest` 정상 통과  

## ⚙성능  
- **CopyOnWriteArrayList** 기반 emitter 관리로 동시성 안정성 확보(낙관적 읽기 다수 시 이점)  
- heart-beat 전송 및 실패 시 emitter 제거로 **좀비 연결 정리** → 불필요한 리소스 소모 방지  
- 초기 meta 이벤트 **지연 전송(≈150ms)**로 접속 직후 헤더/버퍼 안정화 후 데이터 전송  

## ℹ️추가 정보  
- Nginx/프록시 환경에서는 `X-Accel-Buffering: no` 헤더를 통해 **버퍼링 비활성화** 필요  
- 클라이언트는 **EventSource** 사용 권장. 재연결 시 서버는 신규 emitter를 등록하므로 **idempotent**하게 동작  
- JWT와의 연동: 접근 제어는 별도 필터에서 수행, 컨트롤러는 `userNickname` 쿠키만 신뢰  

## ❌이슈  
- 대규모 동시 접속 시 emitter 리스트 관리에 따른 메모리 사용량 증가 가능  
- 모바일 네트워크 환경에서 빈번한 재연결 발생 시 리소스 스파이크 가능 → **재연결 지연(backoff)** 권장
