### PR TITLE
Feat/board profile image - 게시글 프로필 이미지 반환

### DIFF
--- a/src/main/java/com/modureview/dto/response/BoardDetailResponse.java
+++ b/src/main/java/com/modureview/dto/response/BoardDetailResponse.java
@@ -10,6 +10,7 @@ public record BoardDetailResponse(
     Long board_id,
     String title,
     Category category,
+    String profile_image,
     String author_nickname,
     @JsonFormat(pattern = "yyyy-MM-dd HH시 mm분", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
     LocalDateTime created_at,

--- a/src/main/java/com/modureview/service/BoardService.java
+++ b/src/main/java/com/modureview/service/BoardService.java
@@ -69,10 +69,12 @@ public class BoardService {
     Board findBoard = boardRepository.findById(boardId).orElseThrow(
         () -> new CustomException(BoardErrorCode.BOARD_ID_NOTFOUND)
     );
+    User user = userRepository.findByNickname(findBoard.getNickname()).get();
     return BoardDetailResponse.builder()
         .board_id(findBoard.getId())
         .title(findBoard.getTitle())
         .category(findBoard.getCategory())
+        .profile_image(user.getProfile())
         .author_nickname(findBoard.getNickname())
         .created_at(findBoard.getCreatedAt())
         .content(findBoard.getContent())


### PR DESCRIPTION
## 👀제목
게시글 프로필 이미지 반환

## 🙋변경 사항
게시글 반환 API에 profile이미지 추가 반환

## 💎설명
Board Entity반환 후 usernickname을 통해 user.profile을 리턴한다. 
이때 추가적으로 쿼리가 +1 들어가게되어 해당 로직을 위해 총 2개의 sql쿼리가 실행된다. 


## ❌이슈
서비스 출시를 위해 빠른 개발을 선택했다. N+1문제는 추후에 리팩토링할 예정이다. 