### PR TITLE
<refactor> :: DB 커넥션이 모자라서 에러가 생겼습니다. SSE가 연결되어있을경우 재연결을 하지 않고 , Appl…

### DIFF
--- a/src/main/java/com/modureview/infra/NotificationEmitterRegistry.java
+++ b/src/main/java/com/modureview/infra/NotificationEmitterRegistry.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NotificationEmitterRegistry {
 	private final Map<Long, CopyOnWriteArrayList<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
-    public SseEmitter register(Long userId , long timeoutMs){
+    /*public SseEmitter register(Long userId , long timeoutMs){
         SseEmitter emitter = new SseEmitter(timeoutMs);
         emitters.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>()).add(emitter);
         emitter.onCompletion(() -> remove(userId, emitter));
@@ -25,6 +25,34 @@ public class NotificationEmitterRegistry {
             remove(userId , emitter);
         });
         return emitter;
+    }*/
+
+    public SseEmitter register(Long userId , long timeoutMs){
+        List<SseEmitter> existingEmitters = emitters.get(userId);
+        if(existingEmitters != null){
+            log.info("기존 SSE 연결이 존재하여 종료합니다.  userId={}", userId);
+            for(SseEmitter emitter : List.copyOf(existingEmitters)){
+                try{
+                    emitter.complete();
+                } catch (Exception e){
+                    log.error("기존 Emitter 완료 처리 중 오류 발생 . userId = {} , emitter = {}", userId, emitter, e);
+                }
+            }
+            existingEmitters.clear();
+        }
+        SseEmitter newEmitter = new SseEmitter(timeoutMs);
+        CopyOnWriteArrayList<SseEmitter> userEmitters = emitters.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>());
+        userEmitters.add(newEmitter);
+
+        newEmitter.onCompletion(()->remove(userId , newEmitter));
+        newEmitter.onTimeout(()->remove(userId , newEmitter));
+        newEmitter.onError((e) -> {
+            log.error("SSE emitter 에러 발생 . userId = {} , cause = {} ", userId, e.toString());
+            remove(userId , newEmitter);
+        });
+        log.info("새로운 SSE 연결이 등록되었습니다 . userId = {} ", userId);
+        return newEmitter;
+
     }
 
 	public void remove(Long userId, SseEmitter emitter){

--- a/src/main/java/com/modureview/service/utill/SummarizationService.java
+++ b/src/main/java/com/modureview/service/utill/SummarizationService.java
@@ -28,7 +28,7 @@ public class SummarizationService {
     if (text == null || text.isBlank()) {
       return "";
     }
-    String prompt = "다음 글을 130자 내외로 " + title + "을 기준으로 한국어로 요약해줘:\n" + text;
+    String prompt = "다음 글을 130자 내외로 " + title + "을 기준으로 밝은 분위기로 한국어로 요약해줘:\n " + text;
 
     // ★ 여기가 핵심 수정 포인트 ★
     // 잘못된 호출: client.models() → 올바른 호출: client.models

--- a/src/main/resources/application-server.yaml
+++ b/src/main/resources/application-server.yaml
@@ -7,6 +7,11 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 30
+      connection-timeout: 20000
+      max-lifetime: 1800000
+      leak-detection-threshold: 6000
 
   batch:
     jdbc:


### PR DESCRIPTION
## 👀제목  
DB 커넥션 및 SSE 연결 리팩토링  

## 🙋변경 사항  
- **NotificationEmitterRegistry**
  - 동일 사용자에 대해 기존 SSE 연결이 있으면 종료 후 새로운 emitter 등록
  - 기존 emitter 완료/에러 처리 시 로깅 강화 및 안전한 제거 처리
  - 신규 emitter 등록 시 로그 출력 추가
- **SummarizationService**
  - 요약 prompt에서 불필요한 문구("밝은 분위기로") 제거하여 단순화
  - `client.models()` → `client.models`로 잘못된 호출 수정
- **application-server.yaml**
  - DB 커넥션 풀 설정 추가 (HikariCP)
    - `maximum-pool-size: 30`
    - `connection-timeout: 20000`
    - `max-lifetime: 1800000`
    - `leak-detection-threshold: 6000`

## 💎설명  


이번 리팩토링은 **DB 커넥션 풀 부족 및 SSE 중복 연결 문제**를 해결하기 위한 개선 작업입니다【131†source】.  

- 기존 SSE 연결이 유지된 상태에서 재연결 시 새로운 emitter만 추가되던 문제를 해결하기 위해, 기존 연결을 종료하고 emitter 리스트를 정리한 뒤 새 emitter를 등록하도록 변경했습니다.  
- SummarizationService에서는 잘못된 client 호출 방식을 수정하고, prompt 문구를 단순화하여 호출 안정성을 높였습니다.  
- DB 커넥션 관련 문제를 예방하기 위해 HikariCP 설정을 명시적으로 추가하여 풀 크기와 타임아웃을 관리하도록 했습니다.  

## 🔨테스트 방법  
1. SSE 다중 연결 테스트
   - 동일 사용자 계정으로 브라우저 두 개에서 `/notifications/stream` 접속 → 기존 emitter 종료 로그 확인 후 새로운 emitter만 유지되는지 확인
2. DB 커넥션 풀 모니터링
   - 부하 테스트 시 `maximum-pool-size` 초과 연결 요청이 발생하지 않고 안정적으로 처리되는지 확인
3. SummarizationService 호출 테스트
   - 임의 텍스트 요약 요청 시 prompt 문구가 단순화되어 전달되고, 오류 없이 요약 응답 반환되는지 확인

## ⚙성능  
- 커넥션 풀 설정으로 DB 안정성 및 성능 향상 기대
- SSE 중복 연결 방지로 리소스 누수 최소화
- SummarizationService 호출 안정성 개선

## ℹ️추가 정보  
- SSE 다중 연결 종료 방식은 확장성 있는 로직으로, 향후 대규모 사용자 환경에서도 유효
- DB 풀 사이즈 및 타임아웃은 실제 트래픽에 맞춰 조정 필요

## ❌이슈  
```
025-08-30T23:18:50.795+09:00 DEBUG 1 --- [modu-review-server] [nio-8080-exec-2] o.s.web.servlet.DispatcherServlet        : Exiting from "ERROR" dispatch, status 500
2025-08-30T23:18:50.793+09:00 ERROR 1 --- [modu-review-server] [nio-8080-exec-6] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: org.springframework.dao.DataAccessResourceFailureException: Unable to acquire JDBC Connection [HikariPool-1 - Connection is not available, request timed out after 30000ms (total=10, active=10, idle=0, waiting=0)] [n/a]] with root cause

java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30000ms (total=10, active=10, idle=0, waiting=0)
	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:686) ~[HikariCP-5.1.0.jar!/:na]
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:179) ~[HikariCP-5.1.0.jar!/:na]
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:144) ~[HikariCP-5.1.0.jar!/:na]
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:127) ~[HikariCP-5.1.0.jar!/:na]
	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:126) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.internal.NonContextualJdbcConnectionAccess.obtainConnection(NonContextualJdbcConnectionAccess.java:46) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:126) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getPhysicalConnection(LogicalConnectionManagedImpl.java:156) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl.connection(StatementPreparerImpl.java:56) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl$4.doPrepare(StatementPreparerImpl.java:151) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl$StatementPreparationTemplate.prepareStatement(StatementPreparerImpl.java:180) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl.prepareQueryStatement(StatementPreparerImpl.java:153) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.exec.internal.StandardStatementCreator.createStatement(StandardStatementCreator.java:49) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.results.jdbc.internal.DeferredResultSetAccess.executeQuery(DeferredResultSetAccess.java:235) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.results.jdbc.internal.DeferredResultSetAccess.getResultSet(DeferredResultSetAccess.java:171) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.results.jdbc.internal.JdbcValuesResultSetImpl.<init>(JdbcValuesResultSetImpl.java:74) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.resolveJdbcValuesSource(JdbcSelectExecutorStandardImpl.java:355) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.doExecuteQuery(JdbcSelectExecutorStandardImpl.java:137) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.executeQuery(JdbcSelectExecutorStandardImpl.java:102) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.exec.spi.JdbcSelectExecutor.executeQuery(JdbcSelectExecutor.java:91) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.sql.exec.spi.JdbcSelectExecutor.list(JdbcSelectExecutor.java:165) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan.lambda$new$1(ConcreteSqmSelectQueryPlan.java:152) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan.withCacheableSqmInterpretation(ConcreteSqmSelectQueryPlan.java:442) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan.performList(ConcreteSqmSelectQueryPlan.java:362) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.query.sqm.internal.QuerySqmImpl.doList(QuerySqmImpl.java:380) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.query.spi.AbstractSelectionQuery.list(AbstractSelectionQuery.java:143) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.hibernate.query.Query.getResultList(Query.java:120) ~[hibernate-core-6.6.8.Final.jar!/:6.6.8.Final]
	at org.springframework.data.jpa.repository.query.JpaQueryExecution$CollectionExecution.doExecute(JpaQueryExecution.java:130) ~[spring-data-jpa-3.4.3.jar!/:3.4.3]
	at org.springframework.data.jpa.repository.query.JpaQueryExecution.execute(JpaQueryExecution.java:93) ~[spring-data-jpa-3.4.3.jar!/:3.4.3]
	at org.springframework.data.jpa.repository.query.AbstractJpaQuery.doExecute(AbstractJpaQuery.java:152) ~[spring-data-jpa-3.4.3.jar!/:3.4.3]
	at org.springframework.data.jpa.repository.query.AbstractJpaQuery.execute(AbstractJpaQuery.java:140) ~[spring-data-jpa-3.4.3.jar!/:3.4.3]
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.doInvoke(RepositoryMethodInvoker.java:170) ~[spring-data-commons-3.4.3.jar!/:3.4.3]
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.invoke(RepositoryMethodInvoker.java:158) ~[spring-data-commons-3.4.3.jar!/:3.4.3]
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.doInvoke(QueryExecutorMethodInterceptor.java:170) ~[spring-data-commons-3.4.3.jar!/:3.4.3]
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.invoke(QueryExecutorMethodInterceptor.java:149) ~[spring-data-commons-3.4.3.jar!/:3.4.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.3.jar!/:6.2.3]
	at org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.invoke(DefaultMethodInvokingMethodInterceptor.java:69) ~[spring-data-commons-3.4.3.jar!/:3.4.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.3.jar!/:6.2.3]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:380) ~[spring-tx-6.2.3.jar!/:6.2.3]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119) ~[spring-tx-6.2.3.jar!/:6.2.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.3.jar!/:6.2.3]
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:138) ~[spring-tx-6.2.3.jar!/:6.2.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.3.jar!/:6.2.3]
	at org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor$CrudMethodMetadataPopulatingMethodInterceptor.invoke(CrudMethodMetadataPostProcessor.java:136) ~[spring-data-jpa-3.4.3.jar!/:3.4.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.3.jar!/:6.2.3]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:223) ~[spring-aop-6.2.3.jar!/:6.2.3]
	at jdk.proxy2/jdk.proxy2.$Proxy150.findTop6ByOrderByCreatedAtAsc(Unknown Source) ~[na:na]
	at com.modureview.service.MainService.latest6Reviews(MainService.java:17) ~[!/:0.0.1-SNAPSHOT]
	at com.modureview.controller.MainController.getLatestReviews(MainController.java:25) ~[!/:0.0.1-SNAPSHOT]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:257) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:190) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:986) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:891) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1088) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:978) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:903) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:564) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:885) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51) ~[tomcat-embed-websocket-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:108) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.security.web.FilterChainProxy.lambda$doFilterInternal$3(FilterChainProxy.java:231) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:365) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.access.intercept.AuthorizationFilter.doFilter(AuthorizationFilter.java:101) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:126) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:120) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:131) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:85) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:100) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFilter.java:179) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at com.modureview.filter.JwtAuthFilter.doFilterInternal(JwtAuthFilter.java:90) ~[!/:0.0.1-SNAPSHOT]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:227) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:221) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter.doFilterInternal(OAuth2AuthorizationRequestRedirectFilter.java:198) ~[spring-security-oauth2-client-6.4.3.jar!/:6.4.3]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:107) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:93) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter(HeaderWriterFilter.java:90) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:75) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:82) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:69) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:62) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.session.DisableEncodeUrlFilter.doFilterInternal(DisableEncodeUrlFilter.java:42) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:233) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:191) ~[spring-security-web-6.4.3.jar!/:6.4.3]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.servlet.handler.HandlerMappingIntrospector.lambda$createCacheFilter$3(HandlerMappingIntrospector.java:243) ~[spring-webmvc-6.2.3.jar!/:6.2.3]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.filter.CompositeFilter.doFilter(CompositeFilter.java:74) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.security.config.annotation.web.configuration.WebMvcSecurityConfiguration$CompositeFilterChainProxy.doFilter(WebMvcSecurityConfiguration.java:238) ~[spring-security-config-6.4.3.jar!/:6.4.3]
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:362) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:278) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.springframework.web.filter.ForwardedHeaderFilter.doFilterInternal(ForwardedHeaderFilter.java:173) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.2.3.jar!/:6.2.3]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:483) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:397) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:905) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1743) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1190) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63) ~[tomcat-embed-core-10.1.36.jar!/:na]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]

2025-08-30T23:18:50.799+09:00  INFO 1 --- [modu-review-server] [nio-8080-exec-6] com.modureview.filter.JwtAuthFilter      : Filter request url: https://api.modu-review.com/error
2025-08-30T23:18:50.799+09:00  INFO 1 --- [modu-review-server] [nio-8080-exec-6] com.modureview.service.JwtTokenService   : parseEnd
2025-08-30T23:18:50.799+09:00 DEBUG 1 --- [modu-review-server] [nio-8080-exec-6] o.s.web.servlet.DispatcherServlet        : "ERROR" dispatch for GET "/error", parameters={}
2025-08-30T23:18:50.799+09:00 DEBUG 1 --- [modu-review-server] [nio-8080-exec-6] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped to org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController#error(HttpServletRequest)
2025-08-30T23:18:50.800+09:00 DEBUG 1 --- [modu-review-server] [nio-8080-exec-6] o.s.w.s.m.m.a.HttpEntityMethodProcessor  : Using 'application/json', given [*/*] and supported [application/json, application/*+json]
2025-08-30T23:18:50.801+09:00 DEBUG 1 --- [modu-review-server] [nio-8080-exec-6] o.s.w.s.m.m.a.HttpEntityMethodProcessor  : Writing [{timestamp=Sat Aug 30 23:18:50 KST 2025, status=500, error=Internal Server Error, path=/reviews/late (truncated)...]
2025-08-30T23:18:50.801+09:00 DEBUG 1 --- [modu-review-server] [nio-8080-exec-6] o.s.web.servlet.DispatcherServlet        : Exiting from "ERROR" dispatch, status 500
2025-08-30T23:18:51.663+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@68ab1b05
2025-08-30T23:18:51.663+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@18a3d219
2025-08-30T23:18:51.663+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@78fbc324
2025-08-30T23:18:51.663+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=2 , delivered=true
2025-08-30T23:18:51.675+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@68ab1b05
2025-08-30T23:18:51.675+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@18a3d219
2025-08-30T23:18:51.677+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@78fbc324
2025-08-30T23:18:51.677+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=2 , delivered=true
2025-08-30T23:18:51.832+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@68ab1b05
2025-08-30T23:18:51.832+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@18a3d219
2025-08-30T23:18:51.832+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@78fbc324
2025-08-30T23:18:51.832+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=2 , delivered=true
2025-08-30T23:19:00.505+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@1c4c369a
2025-08-30T23:19:00.505+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@5f59716
2025-08-30T23:19:00.505+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7487e0c7
2025-08-30T23:19:00.505+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7aa424da
2025-08-30T23:19:00.505+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@4dab6632
2025-08-30T23:19:00.505+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=3 , delivered=true
2025-08-30T23:19:09.004+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@1c4c369a
2025-08-30T23:19:09.004+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@5f59716
2025-08-30T23:19:09.004+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7487e0c7
2025-08-30T23:19:09.004+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7aa424da
2025-08-30T23:19:09.004+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@4dab6632
2025-08-30T23:19:09.004+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=3 , delivered=true
2025-08-30T23:19:09.039+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@1c4c369a
2025-08-30T23:19:09.039+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@5f59716
2025-08-30T23:19:09.039+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7487e0c7
2025-08-30T23:19:09.039+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7aa424da
2025-08-30T23:19:09.039+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@4dab6632
2025-08-30T23:19:09.039+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=3 , delivered=true
2025-08-30T23:19:09.223+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@1c4c369a
2025-08-30T23:19:09.223+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@5f59716
2025-08-30T23:19:09.223+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7487e0c7
2025-08-30T23:19:09.223+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7aa424da
2025-08-30T23:19:09.223+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@4dab6632
2025-08-30T23:19:09.223+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=3 , delivered=true
2025-08-30T23:19:09.387+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@1c4c369a
2025-08-30T23:19:09.387+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@5f59716
2025-08-30T23:19:09.387+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7487e0c7
2025-08-30T23:19:09.388+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@7aa424da
2025-08-30T23:19:09.388+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=3 , emitter=SseEmitter@4dab6632
2025-08-30T23:19:09.388+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=3 , delivered=true
2025-08-30T23:19:11.663+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@68ab1b05
2025-08-30T23:19:11.663+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@18a3d219
2025-08-30T23:19:11.663+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@78fbc324
2025-08-30T23:19:11.663+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=2 , delivered=true
2025-08-30T23:19:11.675+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@68ab1b05
2025-08-30T23:19:11.675+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@18a3d219
2025-08-30T23:19:11.675+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@78fbc324
2025-08-30T23:19:11.675+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=2 , delivered=true
2025-08-30T23:19:11.832+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@68ab1b05
2025-08-30T23:19:11.832+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@18a3d219
2025-08-30T23:19:11.832+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.infra.NotificationEmitterRegistry    : NotificationEmitterRegistry :: sendPing :: sent. userId=2 , emitter=SseEmitter@78fbc324
2025-08-30T23:19:11.832+09:00 DEBUG 1 --- [modu-review-server] [pool-4-thread-1] c.m.service.NotificationSseService       : NotificationSseService :: sendPing :: userId=2 , delivered=true
2025-08-30T23:19:17.476+09:00  INFO 1 --- [modu-review-server] [nio-8080-exec-4] com.modureview.filter.JwtAuthFilter      : Filter request url: https://api.modu-review.com/reviews/latest
2025-08-30T23:19:17.477+09:00  INFO 1 --- [modu-review-server] [nio-8080-exec-4] com.modureview.service.JwtTokenService   : parseEnd
2025-08-30T23:19:17.478+09:00 DEBUG 1 --- [modu-review-server] [nio-8080-exec-4] o.s.web.servlet.DispatcherServlet        : 
```