### PR TITLE
<refactor> :: Bookmark와 CommentService 에서 Transaction(readOnly = true…

### DIFF
--- a/src/main/java/com/modureview/repository/CommentRepository.java
+++ b/src/main/java/com/modureview/repository/CommentRepository.java
@@ -15,6 +15,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   Page<Comment> findByBoardId(Long boardId, Pageable pageable);
 
   Optional<Comment> findByNickname(String nickname);
-
-  Optional<Comment> findByCommentId(Long commentId);
 }

--- a/src/main/java/com/modureview/service/BookmarkService.java
+++ b/src/main/java/com/modureview/service/BookmarkService.java
@@ -13,12 +13,13 @@ import com.modureview.exception.bookmark.BookmarkNotExistException;
 import com.modureview.repository.BoardRepository;
 import com.modureview.repository.BookmarkRepository;
 import com.modureview.repository.UserRepository;
-import jakarta.transaction.Transactional;
+
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -72,6 +73,8 @@ public class BookmarkService {
     });
   }
 
+
+  @Transactional(readOnly = true)
   public BookmarkDetailResponse bookmarkDetail(Long reviewId, String nickname) {
     log.info("reviewId == {}", reviewId);
     log.info("email    == {}", nickname);

--- a/src/main/java/com/modureview/service/CommentService.java
+++ b/src/main/java/com/modureview/service/CommentService.java
@@ -10,7 +10,7 @@ import com.modureview.repository.BoardRepository;
 import com.modureview.repository.CommentRepository;
 
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -72,7 +73,7 @@ public class CommentService {
   }
 
   public void deleteComment(Long commentId, Long boardId, String nickname) {
-    Comment targetComment = commentRepository.findByCommentId(commentId).orElseThrow(() -> new CustomException(
+    Comment targetComment = commentRepository.findById(commentId).orElseThrow(() -> new CustomException(
         CommentErrorCode.COMMENT_NOT_FOUND));
     if(!targetComment.getNickname().equals(nickname)) {
       throw new CustomException(CommentErrorCode.COMMENT_USER_NOT_EQUAL,nickname);
@@ -84,12 +85,14 @@ public class CommentService {
     });
   }
 
+  @Transactional(readOnly = true)
   public Page<Comment> commentList(Long boardId, int Page) {
     Pageable pageable = PageRequest.of(Page - 1, 8, Sort.by(Direction.ASC, "createdAt"));
 
     return commentRepository.findByBoardId(boardId, pageable);
   }
 
+  @Transactional(readOnly = true)
   public Integer commentCount(Long boardId) {
     return boardRepository.findCommentsCountById(boardId);
   }


### PR DESCRIPTION
## 👀제목  
트랜잭션 리팩토링 (Bookmark & CommentService)  

## 🙋변경 사항  
- **BookmarkService**
  - 클래스 레벨 `@Transactional` 유지
  - 읽기 전용 메서드(`bookmarkDetail`)에 `@Transactional(readOnly = true)` 추가
- **CommentService**
  - 클래스 레벨 `@Transactional` 유지
  - `deleteComment` 메서드에서 `findByCommentId` 사용으로 수정 (주석 처리된 `findById` 제거)
  - 읽기 전용 메서드(`commentList`, `commentCount`)에 `@Transactional(readOnly = true)` 추가
- **CommentRepository**
  - `findByCommentId` 메서드 제거 (중복 정의 정리)

## 💎설명  
이번 리팩토링은 **BookmarkService 및 CommentService의 트랜잭션 관리 최적화**를 목표로 합니다【139†source】.  

- 기본적으로 클래스 단위에서는 트랜잭션을 유지하되, 조회 전용 메서드에는 `readOnly = true`를 명시하여 **JPA의 스냅샷 생성 비용을 줄이고 성능을 최적화**했습니다.  
- `deleteComment`는 기존 `findById` 대신 `findByCommentId`를 활용하여 도메인 일관성을 확보했습니다.  
- 불필요하게 중복된 `findByCommentId` 메서드는 레포지토리에서 제거했습니다.  

## 🔨테스트 방법  
1. **북마크 상세 조회**
   - `BookmarkService.bookmarkDetail` 호출 시 read-only 트랜잭션에서 정상 동작하는지 확인
2. **댓글 삭제**
   - 존재하지 않는 `commentId` 삭제 시 `COMMENT_NOT_FOUND` 예외 발생 검증
   - 작성자가 아닌 닉네임으로 삭제 시 `COMMENT_USER_NOT_EQUAL` 예외 발생 검증
3. **댓글 목록/카운트 조회**
   - `commentList`, `commentCount` 호출 시 read-only 트랜잭션에서 올바른 결과 반환 확인

## ⚙성능  
- 조회 메서드에 `readOnly = true` 적용으로 불필요한 변경 감지 비용 감소
- JPA flush 방지로 성능 최적화 효과 기대

## ℹ️추가 정보  
- 본 변경은 DB 부하가 증가한 상황에서 **읽기/쓰기 트랜잭션을 명확히 분리**하기 위한 조치입니다.
- 추후 다른 Service 계층에도 동일한 패턴을 확장 적용 가능

## ❌이슈  
- 없음