### PR TITLE
Hotfix/main service

### DIFF
--- a/src/main/java/com/modureview/repository/BoardRepository.java
+++ b/src/main/java/com/modureview/repository/BoardRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-  List<Board> findTop6ByOrderByCreatedAtAsc();
+  List<Board> findTop6ByOrderByCreatedAtDesc();
 
   @Query(value =
       "WITH RankedBoards AS (" +

--- a/src/main/java/com/modureview/service/MainService.java
+++ b/src/main/java/com/modureview/service/MainService.java
@@ -14,7 +14,7 @@ public class MainService {
   private final BoardRepository boardRepository;
 
   public List<Board> latest6Reviews() {
-    return boardRepository.findTop6ByOrderByCreatedAtAsc();
+    return boardRepository.findTop6ByOrderByCreatedAtDesc();
 
   }
 }

--- a/src/main/java/com/modureview/service/UserService.java
+++ b/src/main/java/com/modureview/service/UserService.java
@@ -1,6 +1,8 @@
 package com.modureview.service;
 
 import com.modureview.entity.User;
+import com.modureview.enums.errors.UserErrorCode;
+import com.modureview.exception.CustomException;
 import com.modureview.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,5 +23,8 @@ public class UserService {
   }
 
   public User findUserByNickname(String nickname) {
+    return userRepository.findByNickname(nickname).orElseThrow(
+        () -> new CustomException(UserErrorCode.USER_NOT_FOUND)
+    );
   }
 }


### PR DESCRIPTION
## 👀제목  
MainService 및 UserService 핫픽스 (최신순 정렬 & 예외처리 추가)  

## 🙋변경 사항  
- **BoardRepository / MainService**
  - `findTop6ByOrderByCreatedAtAsc()` → `findTop6ByOrderByCreatedAtDesc()`로 수정
  - `MainService.latest6Reviews()`에서 최신순으로 게시글 6개 반환하도록 변경
- **UserService**
  - `findUserByNickname(String nickname)` 메서드 예외 처리 강화
  - 존재하지 않는 닉네임 조회 시 `CustomException(UserErrorCode.USER_NOT_FOUND)` 발생

## 💎설명  
이번 핫픽스는 **메인 페이지 최신 리뷰 노출 오류**와 **User 조회 시 누락된 예외 처리**를 수정하는 작업입니다【147†source】.  

- 기존 `MainService`가 오래된 순(ASC)으로 리뷰를 불러오던 문제를 최신순(DESC)으로 변경했습니다. 이로써 메인 화면에 가장 최근 작성된 리뷰가 표시됩니다.
- `UserService.findUserByNickname`에서는 Optional 처리 중 `orElseThrow`를 사용하여, 존재하지 않는 유저 닉네임 조회 시 명확한 예외가 발생하도록 수정했습니다.

## 🔨테스트 방법  
1. **메인 리뷰 최신순 확인**  
   - `/main` 혹은 관련 엔드포인트 호출 시, 최신 작성 순으로 6개의 리뷰가 반환되는지 확인
2. **유저 조회 예외 확인**  
   - 존재하지 않는 닉네임으로 `findUserByNickname` 호출 시 `USER_NOT_FOUND` 예외 발생 검증

## ⚙성능  
- 정렬 조건만 변경되었기 때문에 성능 영향 없음
- UserService 예외 처리 강화로 로직 안정성 향상

## ℹ️추가 정보  
- 본 변경은 운영 중 발견된 **메인 화면 리뷰 정렬 버그**를 긴급 수정한 핫픽스입니다.
- User 조회 예외처리 개선으로 서비스 전반에서 예외 관리 일관성이 강화됨

## ❌이슈  
- 없음